### PR TITLE
Implement modular NestJS backend with auditing

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,20 @@
+{
+  "root": true,
+  "parserOptions": {
+    "project": ["./tsconfig.json"],
+    "tsconfigRootDir": __dirname
+  },
+  "env": {
+    "node": true,
+    "es2021": true
+  },
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "rules": {
+    "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+coverage
+dist
+*.log
+data/*.sqlite*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# BusMedaus
+# BusMedaus Backend
+
+This repository contains a NestJS backend that powers the BusMedaus platform. It provides modules for authentication, user management, hive collaboration, task workflows, messaging, notifications, media management, and audit logging.
+
+## Getting started
+
+```bash
+npm install
+npm run build
+npm start
+```
+
+The service listens on `http://localhost:3000` and persists data to a local SQLite database stored under `data/app.sqlite`.
+
+## Key features
+
+- **Authentication** with bcrypt hashed passwords, short-lived JWT access tokens, and rotating refresh tokens.
+- **Role-based access control** enforced through guards that honour `admin`, `manager`, and `member` roles.
+- **Modular domain APIs** for users, hives, tasks, notifications, messaging, and media with layered controllers, services, and repositories.
+- **Transactional workflows** ensuring hive, task, messaging, and media operations commit atomically.
+- **Auditing middleware** that records every state-changing request and exposes the logs through secure admin endpoints.
+
+All endpoints apply request validation and respond with sanitized payloads that omit sensitive fields.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "busmedaus-backend",
+  "version": "1.0.0",
+  "description": "BusMedaus backend service with NestJS.",
+  "main": "dist/main.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/main.js",
+    "start:dev": "ts-node-dev --respawn src/main.ts",
+    "lint": "eslint .",
+    "test": "echo 'No automated tests yet'"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/typeorm": "^10.0.0",
+    "bcryptjs": "^2.4.3",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.0",
+    "jsonwebtoken": "^9.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.0",
+    "sqlite3": "^5.1.6",
+    "typeorm": "^0.3.17"
+  },
+  "devDependencies": {
+    "@types/bcryptjs": "^2.4.2",
+    "@types/jsonwebtoken": "^9.0.2",
+    "@types/node": "^18.0.0",
+    "eslint": "^8.45.0",
+    "typescript": "^5.2.0",
+    "ts-node": "^10.9.1",
+    "ts-node-dev": "^2.0.0",
+    "@typescript-eslint/eslint-plugin": "^6.7.0",
+    "@typescript-eslint/parser": "^6.7.0",
+    "@types/express": "^4.17.21"
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,0 +1,35 @@
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuditMiddleware } from './audit/audit.middleware';
+import { AuditModule } from './audit/audit.module';
+import { AuthModule } from './auth/auth.module';
+import { MessagingModule } from './messaging/messaging.module';
+import { MediaModule } from './media/media.module';
+import { NotificationsModule } from './notifications/notifications.module';
+import { TasksModule } from './tasks/tasks.module';
+import { HivesModule } from './hives/hives.module';
+import { UsersModule } from './users/users.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forRoot({
+      type: 'sqlite',
+      database: 'data/app.sqlite',
+      autoLoadEntities: true,
+      synchronize: true
+    }),
+    AuditModule,
+    AuthModule,
+    UsersModule,
+    HivesModule,
+    TasksModule,
+    NotificationsModule,
+    MessagingModule,
+    MediaModule
+  ]
+})
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(AuditMiddleware).forRoutes('*');
+  }
+}

--- a/src/audit/audit-log.entity.ts
+++ b/src/audit/audit-log.entity.ts
@@ -1,0 +1,19 @@
+import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity({ name: 'audit_logs' })
+export class AuditLog {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ nullable: true })
+  userId?: string | null;
+
+  @Column()
+  action!: string;
+
+  @Column('text')
+  details!: string;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+}

--- a/src/audit/audit.controller.ts
+++ b/src/audit/audit.controller.ts
@@ -1,0 +1,41 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { AuditService } from './audit.service';
+
+interface AuditLogResponse {
+  id: string;
+  userId?: string | null;
+  action: string;
+  details: Record<string, unknown> | null;
+  createdAt: Date;
+}
+
+@Controller('admin/audit')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class AuditController {
+  constructor(private readonly auditService: AuditService) {}
+
+  @Get()
+  @Roles('admin')
+  async listAuditLogs(@Query('limit') limit?: string): Promise<AuditLogResponse[]> {
+    const parsedLimit = limit ? Math.min(Number(limit), 500) : 100;
+    const logs = await this.auditService.listRecent(Number.isNaN(parsedLimit) ? 100 : parsedLimit);
+    return logs.map((log) => ({
+      id: log.id,
+      userId: log.userId,
+      action: log.action,
+      details: this.safeParse(log.details),
+      createdAt: log.createdAt
+    }));
+  }
+
+  private safeParse(details: string): Record<string, unknown> | null {
+    try {
+      return JSON.parse(details);
+    } catch (error) {
+      return null;
+    }
+  }
+}

--- a/src/audit/audit.middleware.ts
+++ b/src/audit/audit.middleware.ts
@@ -1,0 +1,55 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { AuthenticatedUser } from '../auth/decorators/current-user.decorator';
+import { AuditService } from './audit.service';
+
+@Injectable()
+export class AuditMiddleware implements NestMiddleware {
+  constructor(private readonly auditService: AuditService) {}
+
+  use(req: Request & { user?: AuthenticatedUser }, res: Response, next: NextFunction): void {
+    const start = Date.now();
+    const action = `${req.method} ${req.originalUrl}`;
+
+    res.on('finish', () => {
+      const duration = Date.now() - start;
+      const body = this.redact(req.body);
+      const details = {
+        statusCode: res.statusCode,
+        durationMs: duration,
+        body,
+        query: req.query
+      };
+
+      this.auditService
+        .record(req.user?.userId ?? null, action, details)
+        .catch(() => {
+          /* errors are logged inside the service */
+        });
+    });
+
+    next();
+  }
+
+  private redact(body: unknown): unknown {
+    if (!body || typeof body !== 'object') {
+      return body;
+    }
+
+    if (Array.isArray(body)) {
+      return body.map((entry) => this.redact(entry));
+    }
+
+    return Object.fromEntries(
+      Object.entries(body as Record<string, unknown>).map(([key, value]) => {
+        if (typeof value === 'string' && ['password', 'refreshToken'].includes(key)) {
+          return [key, '[REDACTED]'];
+        }
+        if (typeof value === 'object' && value !== null) {
+          return [key, this.redact(value)];
+        }
+        return [key, value];
+      })
+    );
+  }
+}

--- a/src/audit/audit.module.ts
+++ b/src/audit/audit.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuditController } from './audit.controller';
+import { AuditLog } from './audit-log.entity';
+import { AuditMiddleware } from './audit.middleware';
+import { AuditRepository } from './audit.repository';
+import { AuditService } from './audit.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([AuditLog])],
+  controllers: [AuditController],
+  providers: [AuditService, AuditRepository, AuditMiddleware],
+  exports: [AuditService, AuditRepository, AuditMiddleware]
+})
+export class AuditModule {}

--- a/src/audit/audit.repository.ts
+++ b/src/audit/audit.repository.ts
@@ -1,0 +1,30 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EntityManager, Repository } from 'typeorm';
+import { AuditLog } from './audit-log.entity';
+
+@Injectable()
+export class AuditRepository {
+  private readonly logger = new Logger(AuditRepository.name);
+
+  constructor(
+    @InjectRepository(AuditLog)
+    private readonly repository: Repository<AuditLog>
+  ) {}
+
+  private getRepo(manager?: EntityManager): Repository<AuditLog> {
+    return manager ? manager.getRepository(AuditLog) : this.repository;
+  }
+
+  create(data: Partial<AuditLog>, manager?: EntityManager): AuditLog {
+    return this.getRepo(manager).create(data);
+  }
+
+  save(log: AuditLog, manager?: EntityManager): Promise<AuditLog> {
+    return this.getRepo(manager).save(log);
+  }
+
+  async findRecent(limit = 100): Promise<AuditLog[]> {
+    return this.repository.find({ order: { createdAt: 'DESC' }, take: limit });
+  }
+}

--- a/src/audit/audit.service.ts
+++ b/src/audit/audit.service.ts
@@ -1,0 +1,33 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { AuditLog } from './audit-log.entity';
+import { AuditRepository } from './audit.repository';
+
+@Injectable()
+export class AuditService {
+  private readonly logger = new Logger(AuditService.name);
+
+  constructor(private readonly auditRepository: AuditRepository, private readonly dataSource: DataSource) {}
+
+  async record(userId: string | null, action: string, details: Record<string, unknown>): Promise<void> {
+    try {
+      await this.dataSource.transaction(async (manager) => {
+        const log = this.auditRepository.create(
+          {
+            userId,
+            action,
+            details: JSON.stringify(details)
+          },
+          manager
+        );
+        await this.auditRepository.save(log, manager);
+      });
+    } catch (error) {
+      this.logger.error('Failed to record audit log', error as Error);
+    }
+  }
+
+  listRecent(limit = 100): Promise<AuditLog[]> {
+    return this.auditRepository.findRecent(limit);
+  }
+}

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,0 +1,31 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { AuthService, AuthTokens } from './auth.service';
+import { RegisterDto } from './dto/register.dto';
+import { LoginDto } from './dto/login.dto';
+import { RefreshTokenDto } from './dto/refresh-token.dto';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('register')
+  register(@Body() dto: RegisterDto): Promise<AuthTokens> {
+    return this.authService.register(dto);
+  }
+
+  @Post('login')
+  login(@Body() dto: LoginDto): Promise<AuthTokens> {
+    return this.authService.login(dto);
+  }
+
+  @Post('refresh')
+  refresh(@Body() dto: RefreshTokenDto): Promise<AuthTokens> {
+    return this.authService.refresh(dto);
+  }
+
+  @Post('logout')
+  async logout(@Body() dto: RefreshTokenDto): Promise<{ success: boolean }> {
+    await this.authService.logout(dto.refreshToken);
+    return { success: true };
+  }
+}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UsersModule } from '../users/users.module';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { RefreshToken } from './refresh-token.entity';
+import { RefreshTokenRepository } from './refresh-token.repository';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
+import { RolesGuard } from './guards/roles.guard';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([RefreshToken]), UsersModule],
+  controllers: [AuthController],
+  providers: [AuthService, RefreshTokenRepository, JwtAuthGuard, RolesGuard],
+  exports: [AuthService, JwtAuthGuard, RolesGuard]
+})
+export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,0 +1,181 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { DataSource, EntityManager } from 'typeorm';
+import * as bcrypt from 'bcryptjs';
+import * as jwt from 'jsonwebtoken';
+import { randomUUID } from 'crypto';
+import { UsersService } from '../users/users.service';
+import { RegisterDto } from './dto/register.dto';
+import { LoginDto } from './dto/login.dto';
+import { RefreshTokenDto } from './dto/refresh-token.dto';
+import { RefreshTokenRepository } from './refresh-token.repository';
+import { User } from '../users/user.entity';
+
+interface JwtPayload {
+  sub: string;
+  email: string;
+  roles: string[];
+  tokenId?: string;
+  type: 'access' | 'refresh';
+}
+
+export interface AuthTokens {
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: number;
+  refreshExpiresAt: Date;
+}
+
+@Injectable()
+export class AuthService {
+  private readonly jwtSecret = process.env.JWT_SECRET || 'change-me';
+  private readonly accessTokenExpiry = process.env.JWT_EXPIRES_IN || '15m';
+  private readonly refreshTokenTtlMs = Number(process.env.JWT_REFRESH_TTL_MS || 1000 * 60 * 60 * 24 * 7);
+
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly refreshTokenRepository: RefreshTokenRepository,
+    private readonly dataSource: DataSource
+  ) {}
+
+  async register(dto: RegisterDto): Promise<AuthTokens> {
+    const { accessToken, refreshToken, refreshExpiresAt } = await this.dataSource.transaction(async (manager) => {
+      const user = await this.usersService.createUser(dto, manager);
+      return this.generateTokens(user, manager);
+    });
+
+    const decoded = jwt.decode(accessToken) as jwt.JwtPayload | null;
+    const expiresIn = decoded?.exp ? decoded.exp * 1000 - Date.now() : 0;
+    return { accessToken, refreshToken, expiresIn, refreshExpiresAt };
+  }
+
+  async login(dto: LoginDto): Promise<AuthTokens> {
+    const user = await this.usersService.findByEmail(dto.email);
+    if (!user || !user.isActive) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
+
+    const passwordMatches = await bcrypt.compare(dto.password, user.passwordHash);
+    if (!passwordMatches) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
+
+    const { accessToken, refreshToken, refreshExpiresAt } = await this.generateTokens(user);
+    const decoded = jwt.decode(accessToken) as jwt.JwtPayload | null;
+    const expiresIn = decoded?.exp ? decoded.exp * 1000 - Date.now() : 0;
+    return { accessToken, refreshToken, expiresIn, refreshExpiresAt };
+  }
+
+  async logout(refreshToken: string): Promise<void> {
+    try {
+      const payload = jwt.verify(refreshToken, this.jwtSecret) as JwtPayload;
+      if (payload.type !== 'refresh' || !payload.tokenId) {
+        throw new Error('Invalid token');
+      }
+      const stored = await this.refreshTokenRepository.findByTokenId(payload.tokenId);
+      if (stored) {
+        await this.refreshTokenRepository.revoke(stored);
+        await this.refreshTokenRepository.revokeAllForUser(stored.user.id);
+      }
+    } catch (error) {
+      throw new UnauthorizedException('Invalid refresh token');
+    }
+  }
+
+  async refresh(dto: RefreshTokenDto): Promise<AuthTokens> {
+    const refreshToken = dto.refreshToken;
+    let payload: JwtPayload;
+    try {
+      payload = jwt.verify(refreshToken, this.jwtSecret) as JwtPayload;
+    } catch (error) {
+      throw new UnauthorizedException('Invalid refresh token');
+    }
+
+    if (payload.type !== 'refresh' || !payload.tokenId) {
+      throw new UnauthorizedException('Invalid refresh token');
+    }
+
+    const existing = await this.refreshTokenRepository.findByTokenId(payload.tokenId);
+    if (!existing || existing.revoked) {
+      throw new UnauthorizedException('Refresh token has been revoked');
+    }
+
+    if (existing.expiresAt.getTime() < Date.now()) {
+      await this.refreshTokenRepository.revoke(existing);
+      throw new UnauthorizedException('Refresh token expired');
+    }
+
+    const matches = await bcrypt.compare(refreshToken, existing.tokenHash);
+    if (!matches) {
+      await this.refreshTokenRepository.revoke(existing);
+      throw new UnauthorizedException('Invalid refresh token');
+    }
+
+    const user = existing.user;
+    if (!user.isActive) {
+      throw new UnauthorizedException('Account is disabled');
+    }
+
+    await this.refreshTokenRepository.revoke(existing);
+    const { accessToken, refreshToken: newRefreshToken, refreshExpiresAt } = await this.generateTokens(user);
+    const decoded = jwt.decode(accessToken) as jwt.JwtPayload | null;
+    const expiresIn = decoded?.exp ? decoded.exp * 1000 - Date.now() : 0;
+    return { accessToken, refreshToken: newRefreshToken, expiresIn, refreshExpiresAt };
+  }
+
+  async verifyAccessToken(token: string): Promise<JwtPayload> {
+    try {
+      const payload = jwt.verify(token, this.jwtSecret) as JwtPayload;
+      if (payload.type !== 'access') {
+        throw new Error('Invalid token');
+      }
+      return payload;
+    } catch (error) {
+      throw new UnauthorizedException('Invalid access token');
+    }
+  }
+
+  private async generateTokens(
+    user: User,
+    manager?: EntityManager
+  ): Promise<{ accessToken: string; refreshToken: string; refreshExpiresAt: Date }> {
+    const accessPayload: JwtPayload = {
+      sub: user.id,
+      email: user.email,
+      roles: user.roles,
+      type: 'access'
+    };
+    const accessToken = jwt.sign(accessPayload, this.jwtSecret, {
+      expiresIn: this.accessTokenExpiry
+    });
+
+    const tokenId = randomUUID();
+    const refreshPayload: JwtPayload = {
+      sub: user.id,
+      email: user.email,
+      roles: user.roles,
+      type: 'refresh',
+      tokenId
+    };
+
+    const refreshToken = jwt.sign(refreshPayload, this.jwtSecret, {
+      expiresIn: Math.floor(this.refreshTokenTtlMs / 1000)
+    });
+
+    const refreshExpiresAt = new Date(Date.now() + this.refreshTokenTtlMs);
+    const tokenHash = await bcrypt.hash(refreshToken, 12);
+
+    const tokenEntity = this.refreshTokenRepository.create(
+      {
+        user,
+        tokenId,
+        tokenHash,
+        expiresAt: refreshExpiresAt,
+        revoked: false
+      },
+      manager
+    );
+    await this.refreshTokenRepository.save(tokenEntity, manager);
+
+    return { accessToken, refreshToken, refreshExpiresAt };
+  }
+}

--- a/src/auth/decorators/current-user.decorator.ts
+++ b/src/auth/decorators/current-user.decorator.ts
@@ -1,0 +1,14 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export interface AuthenticatedUser {
+  userId: string;
+  email: string;
+  roles: string[];
+}
+
+export const CurrentUser = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext): AuthenticatedUser | undefined => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.user as AuthenticatedUser | undefined;
+  }
+);

--- a/src/auth/decorators/roles.decorator.ts
+++ b/src/auth/decorators/roles.decorator.ts
@@ -1,0 +1,6 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const ROLES_KEY = 'roles';
+export type Role = 'admin' | 'manager' | 'member';
+
+export const Roles = (...roles: Role[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/auth/dto/login.dto.ts
+++ b/src/auth/dto/login.dto.ts
@@ -1,0 +1,10 @@
+import { IsEmail, IsString, MinLength } from 'class-validator';
+
+export class LoginDto {
+  @IsEmail()
+  email!: string;
+
+  @IsString()
+  @MinLength(8)
+  password!: string;
+}

--- a/src/auth/dto/refresh-token.dto.ts
+++ b/src/auth/dto/refresh-token.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class RefreshTokenDto {
+  @IsString()
+  refreshToken!: string;
+}

--- a/src/auth/dto/register.dto.ts
+++ b/src/auth/dto/register.dto.ts
@@ -1,0 +1,17 @@
+import { ArrayNotEmpty, ArrayUnique, IsArray, IsEmail, IsOptional, IsString, MinLength } from 'class-validator';
+
+export class RegisterDto {
+  @IsEmail()
+  email!: string;
+
+  @IsString()
+  @MinLength(8)
+  password!: string;
+
+  @IsOptional()
+  @IsArray()
+  @ArrayNotEmpty()
+  @ArrayUnique()
+  @IsString({ each: true })
+  roles?: string[];
+}

--- a/src/auth/guards/jwt-auth.guard.ts
+++ b/src/auth/guards/jwt-auth.guard.ts
@@ -1,0 +1,28 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { AuthService } from '../auth.service';
+
+@Injectable()
+export class JwtAuthGuard implements CanActivate {
+  constructor(private readonly authService: AuthService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const authHeader = request.headers['authorization'] as string | undefined;
+    if (!authHeader) {
+      throw new UnauthorizedException('Authorization header missing');
+    }
+
+    const [scheme, token] = authHeader.split(' ');
+    if (scheme !== 'Bearer' || !token) {
+      throw new UnauthorizedException('Invalid authorization header');
+    }
+
+    const payload = await this.authService.verifyAccessToken(token);
+    request.user = {
+      userId: payload.sub,
+      email: payload.email,
+      roles: payload.roles
+    };
+    return true;
+  }
+}

--- a/src/auth/guards/roles.guard.ts
+++ b/src/auth/guards/roles.guard.ts
@@ -1,0 +1,32 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ROLES_KEY, Role } from '../decorators/roles.decorator';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<Role[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass()
+    ]);
+
+    if (!requiredRoles || !requiredRoles.length) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest();
+    const user = request.user as { roles?: string[] } | undefined;
+    if (!user?.roles?.length) {
+      throw new ForbiddenException('Insufficient permissions');
+    }
+
+    const hasRole = requiredRoles.some((role) => user.roles?.includes(role));
+    if (!hasRole) {
+      throw new ForbiddenException('Insufficient permissions');
+    }
+
+    return true;
+  }
+}

--- a/src/auth/refresh-token.entity.ts
+++ b/src/auth/refresh-token.entity.ts
@@ -1,0 +1,32 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn
+} from 'typeorm';
+import { User } from '../users/user.entity';
+
+@Entity({ name: 'refresh_tokens' })
+export class RefreshToken {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @ManyToOne(() => User, (user) => user.refreshTokens, { onDelete: 'CASCADE' })
+  user!: User;
+
+  @Column({ unique: true })
+  tokenId!: string;
+
+  @Column()
+  tokenHash!: string;
+
+  @Column({ type: 'datetime' })
+  expiresAt!: Date;
+
+  @Column({ default: false })
+  revoked!: boolean;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+}

--- a/src/auth/refresh-token.repository.ts
+++ b/src/auth/refresh-token.repository.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EntityManager, Repository } from 'typeorm';
+import { RefreshToken } from './refresh-token.entity';
+
+@Injectable()
+export class RefreshTokenRepository {
+  constructor(
+    @InjectRepository(RefreshToken)
+    private readonly repository: Repository<RefreshToken>
+  ) {}
+
+  private getRepo(manager?: EntityManager): Repository<RefreshToken> {
+    return manager ? manager.getRepository(RefreshToken) : this.repository;
+  }
+
+  create(data: Partial<RefreshToken>, manager?: EntityManager): RefreshToken {
+    return this.getRepo(manager).create(data);
+  }
+
+  save(token: RefreshToken, manager?: EntityManager): Promise<RefreshToken> {
+    return this.getRepo(manager).save(token);
+  }
+
+  findByTokenId(tokenId: string): Promise<RefreshToken | null> {
+    return this.repository.findOne({ where: { tokenId }, relations: ['user'] });
+  }
+
+  findByUserId(userId: string): Promise<RefreshToken[]> {
+    return this.repository.find({ where: { user: { id: userId } }, relations: ['user'] });
+  }
+
+  async revoke(token: RefreshToken): Promise<RefreshToken> {
+    token.revoked = true;
+    return this.repository.save(token);
+  }
+
+  async revokeAllForUser(userId: string): Promise<void> {
+    const tokens = await this.findByUserId(userId);
+    for (const token of tokens) {
+      if (!token.revoked) {
+        token.revoked = true;
+        await this.repository.save(token);
+      }
+    }
+  }
+}

--- a/src/hives/dto/create-hive.dto.ts
+++ b/src/hives/dto/create-hive.dto.ts
@@ -1,0 +1,19 @@
+import { ArrayUnique, IsArray, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+
+export class CreateHiveDto {
+  @IsString()
+  @MinLength(3)
+  @MaxLength(100)
+  name!: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  description?: string;
+
+  @IsOptional()
+  @IsArray()
+  @ArrayUnique()
+  @IsString({ each: true })
+  memberIds?: string[];
+}

--- a/src/hives/dto/manage-hive-member.dto.ts
+++ b/src/hives/dto/manage-hive-member.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, IsUUID } from 'class-validator';
+
+export class ManageHiveMemberDto {
+  @IsString()
+  @IsUUID()
+  userId!: string;
+}

--- a/src/hives/dto/update-hive.dto.ts
+++ b/src/hives/dto/update-hive.dto.ts
@@ -1,0 +1,20 @@
+import { ArrayUnique, IsArray, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+
+export class UpdateHiveDto {
+  @IsOptional()
+  @IsString()
+  @MinLength(3)
+  @MaxLength(100)
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  description?: string;
+
+  @IsOptional()
+  @IsArray()
+  @ArrayUnique()
+  @IsString({ each: true })
+  memberIds?: string[];
+}

--- a/src/hives/hive.entity.ts
+++ b/src/hives/hive.entity.ts
@@ -1,0 +1,45 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinTable,
+  ManyToMany,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn
+} from 'typeorm';
+import { User } from '../users/user.entity';
+import { Task } from '../tasks/task.entity';
+import { MediaItem } from '../media/media-item.entity';
+
+@Entity({ name: 'hives' })
+export class Hive {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column()
+  name!: string;
+
+  @Column({ nullable: true })
+  description?: string;
+
+  @ManyToOne(() => User, (user) => user.ownedHives, { eager: true, onDelete: 'SET NULL' })
+  owner!: User;
+
+  @ManyToMany(() => User, (user) => user.memberHives, { eager: true })
+  @JoinTable({ name: 'hive_members' })
+  members!: User[];
+
+  @OneToMany(() => Task, (task) => task.hive)
+  tasks!: Task[];
+
+  @OneToMany(() => MediaItem, (item) => item.hive)
+  mediaItems!: MediaItem[];
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+}

--- a/src/hives/hives.controller.ts
+++ b/src/hives/hives.controller.ts
@@ -1,0 +1,101 @@
+import { Body, Controller, Delete, Get, Param, Post, Put, UseGuards } from '@nestjs/common';
+import { AuthenticatedUser, CurrentUser } from '../auth/decorators/current-user.decorator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { CreateHiveDto } from './dto/create-hive.dto';
+import { ManageHiveMemberDto } from './dto/manage-hive-member.dto';
+import { UpdateHiveDto } from './dto/update-hive.dto';
+import { Hive } from './hive.entity';
+import { HivesService } from './hives.service';
+
+interface HiveUserSummary {
+  id: string;
+  email: string;
+  roles: string[];
+}
+
+interface HiveResponse {
+  id: string;
+  name: string;
+  description?: string;
+  owner: HiveUserSummary;
+  members: HiveUserSummary[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+function mapUser(user: { id: string; email: string; roles: string[] }): HiveUserSummary {
+  return { id: user.id, email: user.email, roles: user.roles };
+}
+
+function mapHive(hive: Hive): HiveResponse {
+  return {
+    id: hive.id,
+    name: hive.name,
+    description: hive.description,
+    owner: mapUser(hive.owner),
+    members: hive.members.map(mapUser),
+    createdAt: hive.createdAt,
+    updatedAt: hive.updatedAt
+  };
+}
+
+@Controller('hives')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class HivesController {
+  constructor(private readonly hivesService: HivesService) {}
+
+  @Get()
+  async listHives(@CurrentUser() user: AuthenticatedUser): Promise<HiveResponse[]> {
+    const hives = await this.hivesService.listHivesForUser(user);
+    return hives.map(mapHive);
+  }
+
+  @Get(':id')
+  async getHive(@CurrentUser() user: AuthenticatedUser, @Param('id') id: string): Promise<HiveResponse> {
+    const hive = await this.hivesService.getHiveForUser(user, id);
+    return mapHive(hive);
+  }
+
+  @Post()
+  async createHive(@CurrentUser() user: AuthenticatedUser, @Body() dto: CreateHiveDto): Promise<HiveResponse> {
+    const hive = await this.hivesService.createHive(user, dto);
+    return mapHive(hive);
+  }
+
+  @Put(':id')
+  async updateHive(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id') id: string,
+    @Body() dto: UpdateHiveDto
+  ): Promise<HiveResponse> {
+    const hive = await this.hivesService.updateHive(user, id, dto);
+    return mapHive(hive);
+  }
+
+  @Delete(':id')
+  async deleteHive(@CurrentUser() user: AuthenticatedUser, @Param('id') id: string): Promise<{ success: boolean }> {
+    await this.hivesService.removeHive(user, id);
+    return { success: true };
+  }
+
+  @Post(':id/members')
+  async addMember(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id') hiveId: string,
+    @Body() dto: ManageHiveMemberDto
+  ): Promise<HiveResponse> {
+    const hive = await this.hivesService.addMember(user, hiveId, dto);
+    return mapHive(hive);
+  }
+
+  @Delete(':id/members/:memberId')
+  async removeMember(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id') hiveId: string,
+    @Param('memberId') memberId: string
+  ): Promise<HiveResponse> {
+    const hive = await this.hivesService.removeMember(user, hiveId, memberId);
+    return mapHive(hive);
+  }
+}

--- a/src/hives/hives.module.ts
+++ b/src/hives/hives.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { NotificationsModule } from '../notifications/notifications.module';
+import { UsersModule } from '../users/users.module';
+import { Hive } from './hive.entity';
+import { HivesController } from './hives.controller';
+import { HivesRepository } from './hives.repository';
+import { HivesService } from './hives.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Hive]), UsersModule, NotificationsModule],
+  controllers: [HivesController],
+  providers: [HivesService, HivesRepository],
+  exports: [HivesService, HivesRepository]
+})
+export class HivesModule {}

--- a/src/hives/hives.repository.ts
+++ b/src/hives/hives.repository.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EntityManager, Repository } from 'typeorm';
+import { Hive } from './hive.entity';
+
+@Injectable()
+export class HivesRepository {
+  constructor(
+    @InjectRepository(Hive)
+    private readonly repository: Repository<Hive>
+  ) {}
+
+  private getRepo(manager?: EntityManager): Repository<Hive> {
+    return manager ? manager.getRepository(Hive) : this.repository;
+  }
+
+  create(data: Partial<Hive>, manager?: EntityManager): Hive {
+    return this.getRepo(manager).create(data);
+  }
+
+  save(hive: Hive, manager?: EntityManager): Promise<Hive> {
+    return this.getRepo(manager).save(hive);
+  }
+
+  findById(id: string, manager?: EntityManager): Promise<Hive | null> {
+    return this.getRepo(manager).findOne({ where: { id }, relations: ['owner', 'members'] });
+  }
+
+  async findAllForUser(userId: string): Promise<Hive[]> {
+    return this.repository
+      .createQueryBuilder('hive')
+      .leftJoinAndSelect('hive.owner', 'owner')
+      .leftJoinAndSelect('hive.members', 'members')
+      .where('owner.id = :userId', { userId })
+      .orWhere('members.id = :userId', { userId })
+      .getMany();
+  }
+
+  async remove(hive: Hive, manager?: EntityManager): Promise<Hive> {
+    return this.getRepo(manager).remove(hive);
+  }
+
+  findAll(manager?: EntityManager): Promise<Hive[]> {
+    return this.getRepo(manager).find({ relations: ['owner', 'members'] });
+  }
+}

--- a/src/hives/hives.service.ts
+++ b/src/hives/hives.service.ts
@@ -1,0 +1,184 @@
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { AuthenticatedUser } from '../auth/decorators/current-user.decorator';
+import { NotificationsService } from '../notifications/notifications.service';
+import { UsersService } from '../users/users.service';
+import { CreateHiveDto } from './dto/create-hive.dto';
+import { ManageHiveMemberDto } from './dto/manage-hive-member.dto';
+import { UpdateHiveDto } from './dto/update-hive.dto';
+import { Hive } from './hive.entity';
+import { HivesRepository } from './hives.repository';
+
+@Injectable()
+export class HivesService {
+  constructor(
+    private readonly hivesRepository: HivesRepository,
+    private readonly usersService: UsersService,
+    private readonly notificationsService: NotificationsService,
+    private readonly dataSource: DataSource
+  ) {}
+
+  async listHivesForUser(user: AuthenticatedUser): Promise<Hive[]> {
+    if (user.roles.includes('admin')) {
+      return this.hivesRepository.findAll();
+    }
+
+    return this.hivesRepository.findAllForUser(user.userId);
+  }
+
+  async getHiveForUser(user: AuthenticatedUser, hiveId: string): Promise<Hive> {
+    const hive = await this.hivesRepository.findById(hiveId);
+    if (!hive) {
+      throw new NotFoundException(`Hive ${hiveId} not found`);
+    }
+
+    const isMember = hive.owner.id === user.userId || hive.members.some((member) => member.id === user.userId);
+    if (!isMember && !user.roles.includes('admin')) {
+      throw new ForbiddenException('Access denied');
+    }
+
+    return hive;
+  }
+
+  async createHive(user: AuthenticatedUser, dto: CreateHiveDto): Promise<Hive> {
+    const hive = await this.dataSource.transaction(async (manager) => {
+      const owner = await this.usersService.findByIdOrFail(user.userId, manager);
+      const memberEntities = [];
+      if (dto.memberIds) {
+        for (const memberId of dto.memberIds) {
+          const member = await this.usersService.findByIdOrFail(memberId, manager);
+          memberEntities.push(member);
+        }
+      }
+
+      const uniqueMembers = new Map<string, typeof owner>();
+      [owner, ...memberEntities].forEach((member) => {
+        uniqueMembers.set(member.id, member);
+      });
+
+      const hiveEntity = this.hivesRepository.create(
+        {
+          name: dto.name,
+          description: dto.description,
+          owner,
+          members: Array.from(uniqueMembers.values())
+        },
+        manager
+      );
+
+      return this.hivesRepository.save(hiveEntity, manager);
+    });
+
+    const memberIds = hive.members.filter((member) => member.id !== user.userId).map((member) => member.id);
+    if (memberIds.length) {
+      await this.notificationsService.notifyUsers(memberIds, `${user.email} added you to hive ${hive.name}`, {
+        hiveId: hive.id
+      });
+    }
+
+    return hive;
+  }
+
+  async updateHive(user: AuthenticatedUser, hiveId: string, dto: UpdateHiveDto): Promise<Hive> {
+    const hive = await this.dataSource.transaction(async (manager) => {
+      const hiveEntity = await this.hivesRepository.findById(hiveId, manager);
+      if (!hiveEntity) {
+        throw new NotFoundException(`Hive ${hiveId} not found`);
+      }
+
+      this.ensureCanModify(user, hiveEntity);
+
+      if (dto.name) {
+        hiveEntity.name = dto.name;
+      }
+      if (dto.description !== undefined) {
+        hiveEntity.description = dto.description;
+      }
+      if (dto.memberIds) {
+        const members = [];
+        for (const memberId of dto.memberIds) {
+          const member = await this.usersService.findByIdOrFail(memberId, manager);
+          members.push(member);
+        }
+        const map = new Map<string, typeof members[number]>();
+        [hiveEntity.owner, ...members].forEach((member) => map.set(member.id, member));
+        hiveEntity.members = Array.from(map.values());
+      }
+
+      return this.hivesRepository.save(hiveEntity, manager);
+    });
+
+    await this.notificationsService.notifyUsers(
+      hive.members.map((member) => member.id),
+      `Hive ${hive.name} was updated`,
+      { hiveId: hive.id }
+    );
+
+    return hive;
+  }
+
+  async removeHive(user: AuthenticatedUser, hiveId: string): Promise<void> {
+    await this.dataSource.transaction(async (manager) => {
+      const hive = await this.hivesRepository.findById(hiveId, manager);
+      if (!hive) {
+        throw new NotFoundException(`Hive ${hiveId} not found`);
+      }
+      this.ensureCanModify(user, hive);
+      await this.hivesRepository.remove(hive, manager);
+    });
+  }
+
+  async addMember(user: AuthenticatedUser, hiveId: string, dto: ManageHiveMemberDto): Promise<Hive> {
+    const hive = await this.dataSource.transaction(async (manager) => {
+      const hiveEntity = await this.hivesRepository.findById(hiveId, manager);
+      if (!hiveEntity) {
+        throw new NotFoundException(`Hive ${hiveId} not found`);
+      }
+      this.ensureCanModify(user, hiveEntity);
+
+      const member = await this.usersService.findByIdOrFail(dto.userId, manager);
+      if (!hiveEntity.members.some((m) => m.id === member.id)) {
+        hiveEntity.members = [...hiveEntity.members, member];
+      }
+
+      return this.hivesRepository.save(hiveEntity, manager);
+    });
+
+    await this.notificationsService.notifyUsers([dto.userId], `You were added to hive ${hive.name}`, {
+      hiveId: hive.id
+    });
+
+    return hive;
+  }
+
+  async removeMember(user: AuthenticatedUser, hiveId: string, memberId: string): Promise<Hive> {
+    const hive = await this.dataSource.transaction(async (manager) => {
+      const hiveEntity = await this.hivesRepository.findById(hiveId, manager);
+      if (!hiveEntity) {
+        throw new NotFoundException(`Hive ${hiveId} not found`);
+      }
+      this.ensureCanModify(user, hiveEntity);
+
+      hiveEntity.members = hiveEntity.members.filter((member) => member.id !== memberId);
+      if (hiveEntity.owner.id === memberId) {
+        throw new ForbiddenException('Owner cannot be removed from hive');
+      }
+
+      return this.hivesRepository.save(hiveEntity, manager);
+    });
+
+    await this.notificationsService.notifyUsers([memberId], `You were removed from hive ${hive.name}`, {
+      hiveId: hive.id
+    });
+
+    return hive;
+  }
+
+  private ensureCanModify(user: AuthenticatedUser, hive: Hive) {
+    const isOwner = hive.owner.id === user.userId;
+    const hasManagementRole = user.roles.includes('admin') || user.roles.includes('manager');
+    if (!isOwner && !hasManagementRole) {
+      throw new ForbiddenException('Insufficient permissions to modify hive');
+    }
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,18 @@
+import 'reflect-metadata';
+import { NestFactory } from '@nestjs/core';
+import { ValidationPipe } from '@nestjs/common';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true
+    })
+  );
+  await app.listen(3000);
+}
+
+bootstrap();

--- a/src/media/dto/create-media-item.dto.ts
+++ b/src/media/dto/create-media-item.dto.ts
@@ -1,0 +1,23 @@
+import { IsOptional, IsString, IsUrl, IsUUID, MaxLength } from 'class-validator';
+
+export class CreateMediaItemDto {
+  @IsUUID()
+  hiveId!: string;
+
+  @IsUrl()
+  url!: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  type?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  description?: string;
+
+  @IsOptional()
+  @IsString()
+  metadata?: string;
+}

--- a/src/media/dto/update-media-item.dto.ts
+++ b/src/media/dto/update-media-item.dto.ts
@@ -1,0 +1,17 @@
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class UpdateMediaItemDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  type?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  description?: string;
+
+  @IsOptional()
+  @IsString()
+  metadata?: string;
+}

--- a/src/media/media-item.entity.ts
+++ b/src/media/media-item.entity.ts
@@ -1,0 +1,40 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn
+} from 'typeorm';
+import { Hive } from '../hives/hive.entity';
+import { User } from '../users/user.entity';
+
+@Entity({ name: 'media_items' })
+export class MediaItem {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column()
+  url!: string;
+
+  @Column({ nullable: true })
+  type?: string;
+
+  @Column({ nullable: true })
+  description?: string;
+
+  @Column({ nullable: true })
+  metadata?: string;
+
+  @ManyToOne(() => Hive, (hive) => hive.mediaItems, { onDelete: 'CASCADE', eager: true })
+  hive!: Hive;
+
+  @ManyToOne(() => User, (user) => user.mediaItems, { eager: true })
+  uploader!: User;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+}

--- a/src/media/media.controller.ts
+++ b/src/media/media.controller.ts
@@ -1,0 +1,80 @@
+import { Body, Controller, Delete, Get, Param, Post, Put, UseGuards } from '@nestjs/common';
+import { AuthenticatedUser, CurrentUser } from '../auth/decorators/current-user.decorator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { CreateMediaItemDto } from './dto/create-media-item.dto';
+import { UpdateMediaItemDto } from './dto/update-media-item.dto';
+import { MediaItem } from './media-item.entity';
+import { MediaService } from './media.service';
+
+interface MediaResponse {
+  id: string;
+  url: string;
+  type?: string;
+  description?: string;
+  metadata?: string | null;
+  hive: { id: string; name: string };
+  uploader: { id: string; email: string };
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+function mapMedia(item: MediaItem): MediaResponse {
+  return {
+    id: item.id,
+    url: item.url,
+    type: item.type,
+    description: item.description,
+    metadata: item.metadata ?? null,
+    hive: { id: item.hive.id, name: item.hive.name },
+    uploader: { id: item.uploader.id, email: item.uploader.email },
+    createdAt: item.createdAt,
+    updatedAt: item.updatedAt
+  };
+}
+
+@Controller()
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class MediaController {
+  constructor(private readonly mediaService: MediaService) {}
+
+  @Get('hives/:hiveId/media')
+  async listForHive(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('hiveId') hiveId: string
+  ): Promise<MediaResponse[]> {
+    const items = await this.mediaService.listForHive(user, hiveId);
+    return items.map(mapMedia);
+  }
+
+  @Get('media/mine')
+  async listMine(@CurrentUser() user: AuthenticatedUser): Promise<MediaResponse[]> {
+    const items = await this.mediaService.listForUser(user);
+    return items.map(mapMedia);
+  }
+
+  @Post('media')
+  async create(
+    @CurrentUser() user: AuthenticatedUser,
+    @Body() dto: CreateMediaItemDto
+  ): Promise<MediaResponse> {
+    const item = await this.mediaService.create(user, dto);
+    return mapMedia(item);
+  }
+
+  @Put('media/:id')
+  async update(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id') id: string,
+    @Body() dto: UpdateMediaItemDto
+  ): Promise<MediaResponse> {
+    const item = await this.mediaService.update(user, id, dto);
+    return mapMedia(item);
+  }
+
+  @Delete('media/:id')
+  async remove(@CurrentUser() user: AuthenticatedUser, @Param('id') id: string): Promise<{ success: boolean }> {
+    await this.mediaService.remove(user, id);
+    return { success: true };
+  }
+}

--- a/src/media/media.module.ts
+++ b/src/media/media.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { HivesModule } from '../hives/hives.module';
+import { NotificationsModule } from '../notifications/notifications.module';
+import { UsersModule } from '../users/users.module';
+import { MediaController } from './media.controller';
+import { MediaItem } from './media-item.entity';
+import { MediaRepository } from './media.repository';
+import { MediaService } from './media.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([MediaItem]), HivesModule, UsersModule, NotificationsModule],
+  controllers: [MediaController],
+  providers: [MediaService, MediaRepository],
+  exports: [MediaService, MediaRepository]
+})
+export class MediaModule {}

--- a/src/media/media.repository.ts
+++ b/src/media/media.repository.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EntityManager, Repository } from 'typeorm';
+import { MediaItem } from './media-item.entity';
+
+@Injectable()
+export class MediaRepository {
+  constructor(
+    @InjectRepository(MediaItem)
+    private readonly repository: Repository<MediaItem>
+  ) {}
+
+  private getRepo(manager?: EntityManager): Repository<MediaItem> {
+    return manager ? manager.getRepository(MediaItem) : this.repository;
+  }
+
+  create(data: Partial<MediaItem>, manager?: EntityManager): MediaItem {
+    return this.getRepo(manager).create(data);
+  }
+
+  save(item: MediaItem, manager?: EntityManager): Promise<MediaItem> {
+    return this.getRepo(manager).save(item);
+  }
+
+  findById(id: string, manager?: EntityManager): Promise<MediaItem | null> {
+    return this.getRepo(manager).findOne({
+      where: { id },
+      relations: ['hive', 'hive.members', 'hive.owner', 'uploader']
+    });
+  }
+
+  findByHive(hiveId: string): Promise<MediaItem[]> {
+    return this.repository.find({
+      where: { hive: { id: hiveId } },
+      relations: ['hive', 'uploader'],
+      order: { createdAt: 'DESC' }
+    });
+  }
+
+  findByUploader(uploaderId: string): Promise<MediaItem[]> {
+    return this.repository.find({
+      where: { uploader: { id: uploaderId } },
+      relations: ['hive', 'uploader'],
+      order: { createdAt: 'DESC' }
+    });
+  }
+
+  async remove(item: MediaItem, manager?: EntityManager): Promise<MediaItem> {
+    return this.getRepo(manager).remove(item);
+  }
+}

--- a/src/media/media.service.ts
+++ b/src/media/media.service.ts
@@ -1,0 +1,134 @@
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { AuthenticatedUser } from '../auth/decorators/current-user.decorator';
+import { HivesRepository } from '../hives/hives.repository';
+import { NotificationsService } from '../notifications/notifications.service';
+import { UsersService } from '../users/users.service';
+import { CreateMediaItemDto } from './dto/create-media-item.dto';
+import { UpdateMediaItemDto } from './dto/update-media-item.dto';
+import { MediaItem } from './media-item.entity';
+import { MediaRepository } from './media.repository';
+
+@Injectable()
+export class MediaService {
+  constructor(
+    private readonly mediaRepository: MediaRepository,
+    private readonly hivesRepository: HivesRepository,
+    private readonly usersService: UsersService,
+    private readonly notificationsService: NotificationsService,
+    private readonly dataSource: DataSource
+  ) {}
+
+  async listForHive(user: AuthenticatedUser, hiveId: string): Promise<MediaItem[]> {
+    const hive = await this.hivesRepository.findById(hiveId);
+    if (!hive) {
+      throw new NotFoundException(`Hive ${hiveId} not found`);
+    }
+    this.ensureHiveAccess(user, hive.owner.id, hive.members.map((member) => member.id));
+    return this.mediaRepository.findByHive(hiveId);
+  }
+
+  async listForUser(user: AuthenticatedUser): Promise<MediaItem[]> {
+    return this.mediaRepository.findByUploader(user.userId);
+  }
+
+  async create(user: AuthenticatedUser, dto: CreateMediaItemDto): Promise<MediaItem> {
+    const media = await this.dataSource.transaction(async (manager) => {
+      const hive = await this.hivesRepository.findById(dto.hiveId, manager);
+      if (!hive) {
+        throw new NotFoundException(`Hive ${dto.hiveId} not found`);
+      }
+      this.ensureHiveAccess(user, hive.owner.id, hive.members.map((member) => member.id));
+
+      const uploader = await this.usersService.findByIdOrFail(user.userId, manager);
+      const mediaEntity = this.mediaRepository.create(
+        {
+          hive,
+          uploader,
+          url: dto.url,
+          type: dto.type,
+          description: dto.description,
+          metadata: dto.metadata
+        },
+        manager
+      );
+      return this.mediaRepository.save(mediaEntity, manager);
+    });
+
+    const recipients = new Set<string>();
+    media.hive.members.forEach((member) => recipients.add(member.id));
+    recipients.add(media.hive.owner.id);
+    recipients.delete(user.userId);
+
+    if (recipients.size) {
+      await this.notificationsService.notifyUsers(Array.from(recipients), `New media added to ${media.hive.name}`, {
+        mediaId: media.id,
+        hiveId: media.hive.id
+      });
+    }
+
+    return media;
+  }
+
+  async update(user: AuthenticatedUser, mediaId: string, dto: UpdateMediaItemDto): Promise<MediaItem> {
+    const media = await this.dataSource.transaction(async (manager) => {
+      const mediaEntity = await this.mediaRepository.findById(mediaId, manager);
+      if (!mediaEntity) {
+        throw new NotFoundException(`Media item ${mediaId} not found`);
+      }
+      this.ensureMediaManageAccess(user, mediaEntity);
+
+      if (dto.type !== undefined) {
+        mediaEntity.type = dto.type;
+      }
+      if (dto.description !== undefined) {
+        mediaEntity.description = dto.description;
+      }
+      if (dto.metadata !== undefined) {
+        mediaEntity.metadata = dto.metadata;
+      }
+
+      return this.mediaRepository.save(mediaEntity, manager);
+    });
+
+    return media;
+  }
+
+  async remove(user: AuthenticatedUser, mediaId: string): Promise<void> {
+    await this.dataSource.transaction(async (manager) => {
+      const media = await this.mediaRepository.findById(mediaId, manager);
+      if (!media) {
+        throw new NotFoundException(`Media item ${mediaId} not found`);
+      }
+      this.ensureMediaManageAccess(user, media);
+      await this.mediaRepository.remove(media, manager);
+    });
+  }
+
+  private ensureHiveAccess(user: AuthenticatedUser, ownerId: string, memberIds: string[]) {
+    const isMember = ownerId === user.userId || memberIds.includes(user.userId);
+    const isAdmin = user.roles.includes('admin');
+    if (!isMember && !isAdmin) {
+      throw new ForbiddenException('You do not have access to this hive');
+    }
+  }
+
+  private ensureMediaManageAccess(user: AuthenticatedUser, media: MediaItem) {
+    const ownerId = media.hive.owner.id;
+    const memberIds = media.hive.members?.map((member) => member.id) || [];
+    const isUploader = media.uploader.id === user.userId;
+    const hasRole = user.roles.includes('admin') || user.roles.includes('manager');
+    const isOwner = ownerId === user.userId;
+
+    if (isUploader || hasRole || isOwner) {
+      return;
+    }
+
+    const isMember = memberIds.includes(user.userId);
+    if (!isMember) {
+      throw new ForbiddenException('You do not have permission to modify this media item');
+    }
+
+    throw new ForbiddenException('You do not have permission to modify this media item');
+  }
+}

--- a/src/messaging/comment.entity.ts
+++ b/src/messaging/comment.entity.ts
@@ -1,0 +1,27 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn
+} from 'typeorm';
+import { Task } from '../tasks/task.entity';
+import { User } from '../users/user.entity';
+
+@Entity({ name: 'comments' })
+export class Comment {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column('text')
+  content!: string;
+
+  @ManyToOne(() => Task, (task) => task.comments, { onDelete: 'CASCADE' })
+  task!: Task;
+
+  @ManyToOne(() => User, (user) => user.comments, { eager: true })
+  author!: User;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+}

--- a/src/messaging/comments.repository.ts
+++ b/src/messaging/comments.repository.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EntityManager, Repository } from 'typeorm';
+import { Comment } from './comment.entity';
+
+@Injectable()
+export class CommentsRepository {
+  constructor(
+    @InjectRepository(Comment)
+    private readonly repository: Repository<Comment>
+  ) {}
+
+  private getRepo(manager?: EntityManager): Repository<Comment> {
+    return manager ? manager.getRepository(Comment) : this.repository;
+  }
+
+  create(data: Partial<Comment>, manager?: EntityManager): Comment {
+    return this.getRepo(manager).create(data);
+  }
+
+  save(comment: Comment, manager?: EntityManager): Promise<Comment> {
+    return this.getRepo(manager).save(comment);
+  }
+
+  findByTask(taskId: string): Promise<Comment[]> {
+    return this.repository.find({
+      where: { task: { id: taskId } },
+      relations: ['author'],
+      order: { createdAt: 'ASC' }
+    });
+  }
+}

--- a/src/messaging/dto/create-comment.dto.ts
+++ b/src/messaging/dto/create-comment.dto.ts
@@ -1,0 +1,8 @@
+import { IsString, MaxLength, MinLength } from 'class-validator';
+
+export class CreateCommentDto {
+  @IsString()
+  @MinLength(1)
+  @MaxLength(2000)
+  content!: string;
+}

--- a/src/messaging/messaging.controller.ts
+++ b/src/messaging/messaging.controller.ts
@@ -1,0 +1,52 @@
+import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import { AuthenticatedUser, CurrentUser } from '../auth/decorators/current-user.decorator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { CreateCommentDto } from './dto/create-comment.dto';
+import { Comment } from './comment.entity';
+import { MessagingService } from './messaging.service';
+
+interface CommentResponse {
+  id: string;
+  content: string;
+  author: { id: string; email: string; roles: string[] };
+  createdAt: Date;
+}
+
+function mapComment(comment: Comment): CommentResponse {
+  return {
+    id: comment.id,
+    content: comment.content,
+    author: {
+      id: comment.author.id,
+      email: comment.author.email,
+      roles: comment.author.roles
+    },
+    createdAt: comment.createdAt
+  };
+}
+
+@Controller()
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class MessagingController {
+  constructor(private readonly messagingService: MessagingService) {}
+
+  @Get('tasks/:taskId/comments')
+  async listComments(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('taskId') taskId: string
+  ): Promise<CommentResponse[]> {
+    const comments = await this.messagingService.getCommentsForTask(user, taskId);
+    return comments.map(mapComment);
+  }
+
+  @Post('tasks/:taskId/comments')
+  async createComment(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('taskId') taskId: string,
+    @Body() dto: CreateCommentDto
+  ): Promise<CommentResponse> {
+    const comment = await this.messagingService.addComment(user, taskId, dto);
+    return mapComment(comment);
+  }
+}

--- a/src/messaging/messaging.module.ts
+++ b/src/messaging/messaging.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { NotificationsModule } from '../notifications/notifications.module';
+import { TasksModule } from '../tasks/tasks.module';
+import { UsersModule } from '../users/users.module';
+import { Comment } from './comment.entity';
+import { CommentsRepository } from './comments.repository';
+import { MessagingController } from './messaging.controller';
+import { MessagingService } from './messaging.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Comment]), TasksModule, UsersModule, NotificationsModule],
+  controllers: [MessagingController],
+  providers: [MessagingService, CommentsRepository],
+  exports: [MessagingService, CommentsRepository]
+})
+export class MessagingModule {}

--- a/src/messaging/messaging.service.ts
+++ b/src/messaging/messaging.service.ts
@@ -1,0 +1,89 @@
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { AuthenticatedUser } from '../auth/decorators/current-user.decorator';
+import { NotificationsService } from '../notifications/notifications.service';
+import { UsersService } from '../users/users.service';
+import { CreateCommentDto } from './dto/create-comment.dto';
+import { Comment } from './comment.entity';
+import { CommentsRepository } from './comments.repository';
+import { TasksRepository } from '../tasks/tasks.repository';
+
+@Injectable()
+export class MessagingService {
+  constructor(
+    private readonly commentsRepository: CommentsRepository,
+    private readonly tasksRepository: TasksRepository,
+    private readonly usersService: UsersService,
+    private readonly notificationsService: NotificationsService,
+    private readonly dataSource: DataSource
+  ) {}
+
+  async getCommentsForTask(user: AuthenticatedUser, taskId: string): Promise<Comment[]> {
+    const task = await this.tasksRepository.findById(taskId);
+    if (!task) {
+      throw new NotFoundException(`Task ${taskId} not found`);
+    }
+    this.ensureHiveAccess(user, task.hive.id, task.hive.members.map((member) => member.id), task.hive.owner.id);
+    return this.commentsRepository.findByTask(taskId);
+  }
+
+  async addComment(user: AuthenticatedUser, taskId: string, dto: CreateCommentDto): Promise<Comment> {
+    const { comment, recipients } = await this.dataSource.transaction(async (manager) => {
+      const task = await this.tasksRepository.findById(taskId, manager);
+      if (!task) {
+        throw new NotFoundException(`Task ${taskId} not found`);
+      }
+
+      this.ensureHiveAccess(
+        user,
+        task.hive.id,
+        task.hive.members.map((member) => member.id),
+        task.hive.owner.id
+      );
+
+      const author = await this.usersService.findByIdOrFail(user.userId, manager);
+      const commentEntity = this.commentsRepository.create(
+        {
+          content: dto.content,
+          task,
+          author
+        },
+        manager
+      );
+      const saved = await this.commentsRepository.save(commentEntity, manager);
+
+      const recipients = new Set<string>();
+      recipients.add(task.hive.owner.id);
+      task.hive.members.forEach((member) => recipients.add(member.id));
+      if (task.assignedTo) {
+        recipients.add(task.assignedTo.id);
+      }
+      recipients.delete(user.userId);
+
+      return { comment: saved, recipients: Array.from(recipients) };
+    });
+
+    if (recipients.length) {
+      await this.notificationsService.notifyUsers(recipients, `New comment on task ${comment.task.title}`, {
+        taskId: comment.task.id,
+        hiveId: comment.task.hive.id,
+        commentId: comment.id
+      });
+    }
+
+    return comment;
+  }
+
+  private ensureHiveAccess(
+    user: AuthenticatedUser,
+    hiveId: string,
+    memberIds: string[],
+    ownerId: string
+  ) {
+    const isMember = ownerId === user.userId || memberIds.includes(user.userId);
+    const isAdmin = user.roles.includes('admin');
+    if (!isMember && !isAdmin) {
+      throw new ForbiddenException(`You do not have access to hive ${hiveId}`);
+    }
+  }
+}

--- a/src/notifications/notification.entity.ts
+++ b/src/notifications/notification.entity.ts
@@ -1,0 +1,33 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn
+} from 'typeorm';
+import { User } from '../users/user.entity';
+
+@Entity({ name: 'notifications' })
+export class Notification {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @ManyToOne(() => User, (user) => user.notifications, { onDelete: 'CASCADE' })
+  user!: User;
+
+  @Column('text')
+  message!: string;
+
+  @Column({ default: false })
+  read!: boolean;
+
+  @Column({ nullable: true })
+  metadata?: string;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+}

--- a/src/notifications/notifications.controller.ts
+++ b/src/notifications/notifications.controller.ts
@@ -1,0 +1,47 @@
+import { Controller, Get, Param, Patch, UseGuards } from '@nestjs/common';
+import { AuthenticatedUser, CurrentUser } from '../auth/decorators/current-user.decorator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Notification } from './notification.entity';
+import { NotificationsService } from './notifications.service';
+
+interface NotificationResponse {
+  id: string;
+  message: string;
+  metadata?: Record<string, unknown> | null;
+  read: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+function mapNotification(notification: Notification): NotificationResponse {
+  return {
+    id: notification.id,
+    message: notification.message,
+    metadata: notification.metadata ? JSON.parse(notification.metadata) : null,
+    read: notification.read,
+    createdAt: notification.createdAt,
+    updatedAt: notification.updatedAt
+  };
+}
+
+@Controller('notifications')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class NotificationsController {
+  constructor(private readonly notificationsService: NotificationsService) {}
+
+  @Get()
+  async list(@CurrentUser() user: AuthenticatedUser): Promise<NotificationResponse[]> {
+    const notifications = await this.notificationsService.listNotificationsForUser(user.userId);
+    return notifications.map(mapNotification);
+  }
+
+  @Patch(':id/read')
+  async markRead(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id') id: string
+  ): Promise<NotificationResponse> {
+    const notification = await this.notificationsService.markAsRead(user.userId, id);
+    return mapNotification(notification);
+  }
+}

--- a/src/notifications/notifications.module.ts
+++ b/src/notifications/notifications.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UsersModule } from '../users/users.module';
+import { Notification } from './notification.entity';
+import { NotificationsController } from './notifications.controller';
+import { NotificationsRepository } from './notifications.repository';
+import { NotificationsService } from './notifications.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Notification]), UsersModule],
+  controllers: [NotificationsController],
+  providers: [NotificationsService, NotificationsRepository],
+  exports: [NotificationsService, NotificationsRepository]
+})
+export class NotificationsModule {}

--- a/src/notifications/notifications.repository.ts
+++ b/src/notifications/notifications.repository.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EntityManager, Repository } from 'typeorm';
+import { Notification } from './notification.entity';
+
+@Injectable()
+export class NotificationsRepository {
+  constructor(
+    @InjectRepository(Notification)
+    private readonly repository: Repository<Notification>
+  ) {}
+
+  private getRepo(manager?: EntityManager): Repository<Notification> {
+    return manager ? manager.getRepository(Notification) : this.repository;
+  }
+
+  create(data: Partial<Notification>, manager?: EntityManager): Notification {
+    return this.getRepo(manager).create(data);
+  }
+
+  save(notification: Notification, manager?: EntityManager): Promise<Notification> {
+    return this.getRepo(manager).save(notification);
+  }
+
+  findById(id: string, manager?: EntityManager): Promise<Notification | null> {
+    return this.getRepo(manager).findOne({ where: { id }, relations: ['user'] });
+  }
+
+  findByUser(userId: string): Promise<Notification[]> {
+    return this.repository.find({ where: { user: { id: userId } }, order: { createdAt: 'DESC' } });
+  }
+}

--- a/src/notifications/notifications.service.ts
+++ b/src/notifications/notifications.service.ts
@@ -1,0 +1,58 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { UsersService } from '../users/users.service';
+import { Notification } from './notification.entity';
+import { NotificationsRepository } from './notifications.repository';
+
+@Injectable()
+export class NotificationsService {
+  constructor(
+    private readonly notificationsRepository: NotificationsRepository,
+    private readonly usersService: UsersService,
+    private readonly dataSource: DataSource
+  ) {}
+
+  async notifyUsers(
+    userIds: string[],
+    message: string,
+    metadata?: Record<string, unknown>
+  ): Promise<Notification[]> {
+    if (!userIds.length) {
+      return [];
+    }
+
+    const notifications: Notification[] = [];
+    await this.dataSource.transaction(async (manager) => {
+      for (const userId of userIds) {
+        const user = await this.usersService.findByIdOrFail(userId, manager);
+        const notification = this.notificationsRepository.create(
+          {
+            user,
+            message,
+            metadata: metadata ? JSON.stringify(metadata) : undefined,
+            read: false
+          },
+          manager
+        );
+        notifications.push(await this.notificationsRepository.save(notification, manager));
+      }
+    });
+
+    return notifications;
+  }
+
+  listNotificationsForUser(userId: string): Promise<Notification[]> {
+    return this.notificationsRepository.findByUser(userId);
+  }
+
+  async markAsRead(userId: string, notificationId: string): Promise<Notification> {
+    return this.dataSource.transaction(async (manager) => {
+      const notification = await this.notificationsRepository.findById(notificationId, manager);
+      if (!notification || notification.user.id !== userId) {
+        throw new NotFoundException('Notification not found');
+      }
+      notification.read = true;
+      return this.notificationsRepository.save(notification, manager);
+    });
+  }
+}

--- a/src/tasks/dto/create-task.dto.ts
+++ b/src/tasks/dto/create-task.dto.ts
@@ -1,0 +1,25 @@
+import { IsEnum, IsOptional, IsString, IsUUID, MaxLength, MinLength } from 'class-validator';
+import { TaskStatus } from '../task-status.enum';
+
+export class CreateTaskDto {
+  @IsUUID()
+  hiveId!: string;
+
+  @IsString()
+  @MinLength(3)
+  @MaxLength(200)
+  title!: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  description?: string;
+
+  @IsOptional()
+  @IsUUID()
+  assignedToId?: string;
+
+  @IsOptional()
+  @IsEnum(TaskStatus)
+  status?: TaskStatus;
+}

--- a/src/tasks/dto/update-task-status.dto.ts
+++ b/src/tasks/dto/update-task-status.dto.ts
@@ -1,0 +1,7 @@
+import { IsEnum } from 'class-validator';
+import { TaskStatus } from '../task-status.enum';
+
+export class UpdateTaskStatusDto {
+  @IsEnum(TaskStatus)
+  status!: TaskStatus;
+}

--- a/src/tasks/dto/update-task.dto.ts
+++ b/src/tasks/dto/update-task.dto.ts
@@ -1,0 +1,27 @@
+import { IsBoolean, IsEnum, IsOptional, IsString, IsUUID, MaxLength, MinLength } from 'class-validator';
+import { TaskStatus } from '../task-status.enum';
+
+export class UpdateTaskDto {
+  @IsOptional()
+  @IsString()
+  @MinLength(3)
+  @MaxLength(200)
+  title?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  description?: string;
+
+  @IsOptional()
+  @IsUUID()
+  assignedToId?: string;
+
+  @IsOptional()
+  @IsEnum(TaskStatus)
+  status?: TaskStatus;
+
+  @IsOptional()
+  @IsBoolean()
+  unassign?: boolean;
+}

--- a/src/tasks/task-status.enum.ts
+++ b/src/tasks/task-status.enum.ts
@@ -1,0 +1,6 @@
+export enum TaskStatus {
+  TODO = 'todo',
+  IN_PROGRESS = 'in_progress',
+  REVIEW = 'review',
+  DONE = 'done'
+}

--- a/src/tasks/task.entity.ts
+++ b/src/tasks/task.entity.ts
@@ -1,0 +1,43 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn
+} from 'typeorm';
+import { Hive } from '../hives/hive.entity';
+import { User } from '../users/user.entity';
+import { TaskStatus } from './task-status.enum';
+import { Comment } from '../messaging/comment.entity';
+
+@Entity({ name: 'tasks' })
+export class Task {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column()
+  title!: string;
+
+  @Column({ nullable: true })
+  description?: string;
+
+  @Column({ type: 'text', default: TaskStatus.TODO })
+  status!: TaskStatus;
+
+  @ManyToOne(() => Hive, (hive) => hive.tasks, { onDelete: 'CASCADE', eager: true })
+  hive!: Hive;
+
+  @ManyToOne(() => User, (user) => user.assignedTasks, { nullable: true, eager: true })
+  assignedTo?: User | null;
+
+  @OneToMany(() => Comment, (comment) => comment.task)
+  comments!: Comment[];
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+}

--- a/src/tasks/tasks.controller.ts
+++ b/src/tasks/tasks.controller.ts
@@ -1,0 +1,104 @@
+import { Body, Controller, Delete, Get, Param, Patch, Post, Put, UseGuards } from '@nestjs/common';
+import { AuthenticatedUser, CurrentUser } from '../auth/decorators/current-user.decorator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { CreateTaskDto } from './dto/create-task.dto';
+import { UpdateTaskDto } from './dto/update-task.dto';
+import { UpdateTaskStatusDto } from './dto/update-task-status.dto';
+import { Task } from './task.entity';
+import { TasksService } from './tasks.service';
+
+interface TaskUserSummary {
+  id: string;
+  email: string;
+  roles: string[];
+}
+
+interface TaskHiveSummary {
+  id: string;
+  name: string;
+}
+
+interface TaskResponse {
+  id: string;
+  title: string;
+  description?: string;
+  status: string;
+  hive: TaskHiveSummary;
+  assignedTo?: TaskUserSummary | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+function mapUser(user?: { id: string; email: string; roles: string[] } | null): TaskUserSummary | null {
+  if (!user) {
+    return null;
+  }
+  return { id: user.id, email: user.email, roles: user.roles };
+}
+
+function mapTask(task: Task): TaskResponse {
+  return {
+    id: task.id,
+    title: task.title,
+    description: task.description,
+    status: task.status,
+    hive: { id: task.hive.id, name: task.hive.name },
+    assignedTo: mapUser(task.assignedTo),
+    createdAt: task.createdAt,
+    updatedAt: task.updatedAt
+  };
+}
+
+@Controller()
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class TasksController {
+  constructor(private readonly tasksService: TasksService) {}
+
+  @Get('hives/:hiveId/tasks')
+  async listTasks(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('hiveId') hiveId: string
+  ): Promise<TaskResponse[]> {
+    const tasks = await this.tasksService.listTasksForHive(user, hiveId);
+    return tasks.map(mapTask);
+  }
+
+  @Get('tasks/:id')
+  async getTask(@CurrentUser() user: AuthenticatedUser, @Param('id') id: string): Promise<TaskResponse> {
+    const task = await this.tasksService.getTask(user, id);
+    return mapTask(task);
+  }
+
+  @Post('tasks')
+  async createTask(@CurrentUser() user: AuthenticatedUser, @Body() dto: CreateTaskDto): Promise<TaskResponse> {
+    const task = await this.tasksService.createTask(user, dto);
+    return mapTask(task);
+  }
+
+  @Put('tasks/:id')
+  async updateTask(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id') id: string,
+    @Body() dto: UpdateTaskDto
+  ): Promise<TaskResponse> {
+    const task = await this.tasksService.updateTask(user, id, dto);
+    return mapTask(task);
+  }
+
+  @Patch('tasks/:id/status')
+  async updateStatus(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id') id: string,
+    @Body() dto: UpdateTaskStatusDto
+  ): Promise<TaskResponse> {
+    const task = await this.tasksService.updateTaskStatus(user, id, dto);
+    return mapTask(task);
+  }
+
+  @Delete('tasks/:id')
+  async deleteTask(@CurrentUser() user: AuthenticatedUser, @Param('id') id: string): Promise<{ success: boolean }> {
+    await this.tasksService.removeTask(user, id);
+    return { success: true };
+  }
+}

--- a/src/tasks/tasks.module.ts
+++ b/src/tasks/tasks.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { HivesModule } from '../hives/hives.module';
+import { NotificationsModule } from '../notifications/notifications.module';
+import { UsersModule } from '../users/users.module';
+import { Task } from './task.entity';
+import { TasksController } from './tasks.controller';
+import { TasksRepository } from './tasks.repository';
+import { TasksService } from './tasks.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Task]), HivesModule, UsersModule, NotificationsModule],
+  controllers: [TasksController],
+  providers: [TasksService, TasksRepository],
+  exports: [TasksService, TasksRepository]
+})
+export class TasksModule {}

--- a/src/tasks/tasks.repository.ts
+++ b/src/tasks/tasks.repository.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EntityManager, Repository } from 'typeorm';
+import { Task } from './task.entity';
+
+@Injectable()
+export class TasksRepository {
+  constructor(
+    @InjectRepository(Task)
+    private readonly repository: Repository<Task>
+  ) {}
+
+  private getRepo(manager?: EntityManager): Repository<Task> {
+    return manager ? manager.getRepository(Task) : this.repository;
+  }
+
+  create(data: Partial<Task>, manager?: EntityManager): Task {
+    return this.getRepo(manager).create(data);
+  }
+
+  save(task: Task, manager?: EntityManager): Promise<Task> {
+    return this.getRepo(manager).save(task);
+  }
+
+  findById(id: string, manager?: EntityManager): Promise<Task | null> {
+    return this.getRepo(manager).findOne({
+      where: { id },
+      relations: ['hive', 'assignedTo', 'hive.owner', 'hive.members']
+    });
+  }
+
+  async remove(task: Task, manager?: EntityManager): Promise<Task> {
+    return this.getRepo(manager).remove(task);
+  }
+
+  findByHive(hiveId: string): Promise<Task[]> {
+    return this.repository.find({
+      where: { hive: { id: hiveId } },
+      relations: ['hive', 'assignedTo'],
+      order: { createdAt: 'DESC' }
+    });
+  }
+}

--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -1,0 +1,186 @@
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { AuthenticatedUser } from '../auth/decorators/current-user.decorator';
+import { NotificationsService } from '../notifications/notifications.service';
+import { UsersService } from '../users/users.service';
+import { CreateTaskDto } from './dto/create-task.dto';
+import { UpdateTaskDto } from './dto/update-task.dto';
+import { UpdateTaskStatusDto } from './dto/update-task-status.dto';
+import { Task } from './task.entity';
+import { TaskStatus } from './task-status.enum';
+import { TasksRepository } from './tasks.repository';
+import { HivesRepository } from '../hives/hives.repository';
+import { Hive } from '../hives/hive.entity';
+
+@Injectable()
+export class TasksService {
+  constructor(
+    private readonly tasksRepository: TasksRepository,
+    private readonly hivesRepository: HivesRepository,
+    private readonly usersService: UsersService,
+    private readonly notificationsService: NotificationsService,
+    private readonly dataSource: DataSource
+  ) {}
+
+  async listTasksForHive(user: AuthenticatedUser, hiveId: string): Promise<Task[]> {
+    const hive = await this.hivesRepository.findById(hiveId);
+    if (!hive) {
+      throw new NotFoundException(`Hive ${hiveId} not found`);
+    }
+    this.ensureHiveAccess(user, hive);
+    return this.tasksRepository.findByHive(hiveId);
+  }
+
+  async getTask(user: AuthenticatedUser, taskId: string): Promise<Task> {
+    const task = await this.tasksRepository.findById(taskId);
+    if (!task) {
+      throw new NotFoundException(`Task ${taskId} not found`);
+    }
+    this.ensureHiveAccess(user, task.hive);
+    return task;
+  }
+
+  async createTask(user: AuthenticatedUser, dto: CreateTaskDto): Promise<Task> {
+    const task = await this.dataSource.transaction(async (manager) => {
+      const hive = await this.hivesRepository.findById(dto.hiveId, manager);
+      if (!hive) {
+        throw new NotFoundException(`Hive ${dto.hiveId} not found`);
+      }
+      this.ensureHiveAccess(user, hive);
+
+      let assignee = null;
+      if (dto.assignedToId) {
+        assignee = await this.usersService.findByIdOrFail(dto.assignedToId, manager);
+        this.ensureUserInHive(assignee.id, hive);
+      }
+
+      const taskEntity = this.tasksRepository.create(
+        {
+          title: dto.title,
+          description: dto.description,
+          status: dto.status ?? TaskStatus.TODO,
+          hive,
+          assignedTo: assignee
+        },
+        manager
+      );
+
+      return this.tasksRepository.save(taskEntity, manager);
+    });
+
+    if (task.assignedTo) {
+      await this.notificationsService.notifyUsers(
+        [task.assignedTo.id],
+        `You were assigned to task ${task.title}`,
+        { taskId: task.id, hiveId: task.hive.id }
+      );
+    }
+
+    return task;
+  }
+
+  async updateTask(user: AuthenticatedUser, taskId: string, dto: UpdateTaskDto): Promise<Task> {
+    const { task, notifyAssignee } = await this.dataSource.transaction(async (manager) => {
+      const taskEntity = await this.tasksRepository.findById(taskId, manager);
+      if (!taskEntity) {
+        throw new NotFoundException(`Task ${taskId} not found`);
+      }
+      this.ensureTaskManageAccess(user, taskEntity);
+
+      if (dto.title) {
+        taskEntity.title = dto.title;
+      }
+      if (dto.description !== undefined) {
+        taskEntity.description = dto.description;
+      }
+
+      let notifyAssignedUser: string | null = null;
+
+      if (dto.unassign) {
+        taskEntity.assignedTo = null;
+      }
+
+      if (dto.assignedToId !== undefined) {
+        const previousAssignee = taskEntity.assignedTo?.id;
+        const assignee = await this.usersService.findByIdOrFail(dto.assignedToId, manager);
+        this.ensureUserInHive(assignee.id, taskEntity.hive);
+        taskEntity.assignedTo = assignee;
+        if (previousAssignee !== assignee.id) {
+          notifyAssignedUser = assignee.id;
+        }
+      }
+
+      if (dto.status) {
+        taskEntity.status = dto.status;
+      }
+
+      const saved = await this.tasksRepository.save(taskEntity, manager);
+      return { task: saved, notifyAssignee: notifyAssignedUser };
+    });
+
+    if (notifyAssignee) {
+      await this.notificationsService.notifyUsers(
+        [notifyAssignee],
+        `You were assigned to task ${task.title}`,
+        { taskId: task.id, hiveId: task.hive.id }
+      );
+    }
+
+    return task;
+  }
+
+  async updateTaskStatus(user: AuthenticatedUser, taskId: string, dto: UpdateTaskStatusDto): Promise<Task> {
+    const task = await this.dataSource.transaction(async (manager) => {
+      const taskEntity = await this.tasksRepository.findById(taskId, manager);
+      if (!taskEntity) {
+        throw new NotFoundException(`Task ${taskId} not found`);
+      }
+      this.ensureTaskManageAccess(user, taskEntity);
+      taskEntity.status = dto.status;
+      return this.tasksRepository.save(taskEntity, manager);
+    });
+
+    const memberIds = task.hive.members.map((member) => member.id);
+    await this.notificationsService.notifyUsers(memberIds, `Task ${task.title} status changed to ${task.status}`, {
+      taskId: task.id,
+      hiveId: task.hive.id
+    });
+
+    return task;
+  }
+
+  async removeTask(user: AuthenticatedUser, taskId: string): Promise<void> {
+    await this.dataSource.transaction(async (manager) => {
+      const task = await this.tasksRepository.findById(taskId, manager);
+      if (!task) {
+        throw new NotFoundException(`Task ${taskId} not found`);
+      }
+      this.ensureTaskManageAccess(user, task);
+      await this.tasksRepository.remove(task, manager);
+    });
+  }
+
+  private ensureHiveAccess(user: AuthenticatedUser, hive: Hive) {
+    const isMember = hive.owner.id === user.userId || hive.members.some((member) => member.id === user.userId);
+    const isAdmin = user.roles.includes('admin');
+    if (!isMember && !isAdmin) {
+      throw new ForbiddenException('You do not have access to this hive');
+    }
+  }
+
+  private ensureTaskManageAccess(user: AuthenticatedUser, task: Task) {
+    const isOwner = task.hive.owner.id === user.userId;
+    const isAssignee = task.assignedTo?.id === user.userId;
+    const hasRole = user.roles.includes('admin') || user.roles.includes('manager');
+    if (!isOwner && !isAssignee && !hasRole) {
+      throw new ForbiddenException('You do not have permission to manage this task');
+    }
+  }
+
+  private ensureUserInHive(userId: string, hive: Hive) {
+    const isMember = hive.owner.id === userId || hive.members.some((member) => member.id === userId);
+    if (!isMember) {
+      throw new ForbiddenException('Assignee must belong to the hive');
+    }
+  }
+}

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -1,0 +1,17 @@
+import { ArrayNotEmpty, ArrayUnique, IsArray, IsEmail, IsOptional, IsString, MinLength } from 'class-validator';
+
+export class CreateUserDto {
+  @IsEmail()
+  email!: string;
+
+  @IsString()
+  @MinLength(8)
+  password!: string;
+
+  @IsOptional()
+  @IsArray()
+  @ArrayNotEmpty()
+  @ArrayUnique()
+  @IsString({ each: true })
+  roles?: string[];
+}

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -1,0 +1,13 @@
+import { ArrayUnique, IsArray, IsBoolean, IsOptional, IsString } from 'class-validator';
+
+export class UpdateUserDto {
+  @IsOptional()
+  @IsArray()
+  @ArrayUnique()
+  @IsString({ each: true })
+  roles?: string[];
+
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean;
+}

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -1,0 +1,62 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinTable,
+  ManyToMany,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn
+} from 'typeorm';
+import { Hive } from '../hives/hive.entity';
+import { Task } from '../tasks/task.entity';
+import { Notification } from '../notifications/notification.entity';
+import { Comment } from '../messaging/comment.entity';
+import { MediaItem } from '../media/media-item.entity';
+import { RefreshToken } from '../auth/refresh-token.entity';
+
+@Entity({ name: 'users' })
+export class User {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ unique: true })
+  email!: string;
+
+  @Column()
+  passwordHash!: string;
+
+  @Column('simple-array')
+  roles!: string[];
+
+  @Column({ default: true })
+  isActive!: boolean;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+
+  @OneToMany(() => Hive, (hive) => hive.owner)
+  ownedHives!: Hive[];
+
+  @ManyToMany(() => Hive, (hive) => hive.members)
+  @JoinTable({ name: 'hive_members' })
+  memberHives!: Hive[];
+
+  @OneToMany(() => Task, (task) => task.assignedTo)
+  assignedTasks!: Task[];
+
+  @OneToMany(() => Notification, (notification) => notification.user)
+  notifications!: Notification[];
+
+  @OneToMany(() => Comment, (comment) => comment.author)
+  comments!: Comment[];
+
+  @OneToMany(() => MediaItem, (item) => item.uploader)
+  mediaItems!: MediaItem[];
+
+  @OneToMany(() => RefreshToken, (token) => token.user)
+  refreshTokens!: RefreshToken[];
+}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,0 +1,56 @@
+import { Body, Controller, Get, Param, Patch, Post, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { CurrentUser, AuthenticatedUser } from '../auth/decorators/current-user.decorator';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { CreateUserDto } from './dto/create-user.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
+import { UsersService } from './users.service';
+import { User } from './user.entity';
+
+interface SafeUser {
+  id: string;
+  email: string;
+  roles: string[];
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+function toSafeUser(user: User): SafeUser {
+  const { id, email, roles, isActive, createdAt, updatedAt } = user;
+  return { id, email, roles, isActive, createdAt, updatedAt };
+}
+
+@Controller('users')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get('me')
+  async getMe(@CurrentUser() user: AuthenticatedUser): Promise<SafeUser> {
+    const entity = await this.usersService.findByIdOrFail(user.userId);
+    return toSafeUser(entity);
+  }
+
+  @Roles('admin')
+  @Get()
+  async listUsers(): Promise<SafeUser[]> {
+    const users = await this.usersService.listUsers();
+    return users.map(toSafeUser);
+  }
+
+  @Roles('admin')
+  @Post()
+  async createUser(@Body() dto: CreateUserDto): Promise<SafeUser> {
+    const user = await this.usersService.createUser(dto);
+    return toSafeUser(user);
+  }
+
+  @Roles('admin')
+  @Patch(':id')
+  async updateUser(@Param('id') id: string, @Body() dto: UpdateUserDto): Promise<SafeUser> {
+    const user = await this.usersService.updateUser(id, dto);
+    return toSafeUser(user);
+  }
+}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UsersController } from './users.controller';
+import { User } from './user.entity';
+import { UsersRepository } from './users.repository';
+import { UsersService } from './users.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User])],
+  controllers: [UsersController],
+  providers: [UsersService, UsersRepository],
+  exports: [UsersService, UsersRepository]
+})
+export class UsersModule {}

--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EntityManager, Repository } from 'typeorm';
+import { User } from './user.entity';
+
+@Injectable()
+export class UsersRepository {
+  constructor(
+    @InjectRepository(User)
+    private readonly repository: Repository<User>
+  ) {}
+
+  private getRepo(manager?: EntityManager): Repository<User> {
+    return manager ? manager.getRepository(User) : this.repository;
+  }
+
+  create(data: Partial<User>, manager?: EntityManager): User {
+    return this.getRepo(manager).create(data);
+  }
+
+  save(user: User, manager?: EntityManager): Promise<User> {
+    return this.getRepo(manager).save(user);
+  }
+
+  findByEmail(email: string, manager?: EntityManager): Promise<User | null> {
+    return this.getRepo(manager).findOne({ where: { email } });
+  }
+
+  findById(id: string, manager?: EntityManager): Promise<User | null> {
+    return this.getRepo(manager).findOne({ where: { id } });
+  }
+
+  findAll(manager?: EntityManager): Promise<User[]> {
+    return this.getRepo(manager).find();
+  }
+}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,0 +1,63 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { EntityManager } from 'typeorm';
+import * as bcrypt from 'bcryptjs';
+import { CreateUserDto } from './dto/create-user.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
+import { User } from './user.entity';
+import { UsersRepository } from './users.repository';
+
+@Injectable()
+export class UsersService {
+  constructor(private readonly usersRepository: UsersRepository) {}
+
+  async createUser(dto: CreateUserDto, manager?: EntityManager): Promise<User> {
+    const existing = await this.usersRepository.findByEmail(dto.email.toLowerCase(), manager);
+    if (existing) {
+      throw new BadRequestException('Email is already registered.');
+    }
+
+    const passwordHash = await bcrypt.hash(dto.password, 12);
+    const user = this.usersRepository.create({
+      email: dto.email.toLowerCase(),
+      passwordHash,
+      roles: dto.roles?.length ? dto.roles : ['member'],
+      isActive: true
+    }, manager);
+
+    return this.usersRepository.save(user, manager);
+  }
+
+  findByEmail(email: string, manager?: EntityManager): Promise<User | null> {
+    return this.usersRepository.findByEmail(email.toLowerCase(), manager);
+  }
+
+  async findByIdOrFail(id: string, manager?: EntityManager): Promise<User> {
+    const user = await this.usersRepository.findById(id, manager);
+    if (!user) {
+      throw new NotFoundException(`User ${id} not found`);
+    }
+
+    return user;
+  }
+
+  listUsers(manager?: EntityManager): Promise<User[]> {
+    return this.usersRepository.findAll(manager);
+  }
+
+  async updateUser(id: string, dto: UpdateUserDto, manager?: EntityManager): Promise<User> {
+    const user = await this.findByIdOrFail(id, manager);
+
+    if (dto.roles) {
+      if (!dto.roles.length) {
+        throw new BadRequestException('Roles cannot be empty.');
+      }
+      user.roles = dto.roles;
+    }
+
+    if (typeof dto.isActive === 'boolean') {
+      user.isActive = dto.isActive;
+    }
+
+    return this.usersRepository.save(user, manager);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2019",
+    "declaration": false,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- scaffold a NestJS application with TypeORM, SQLite, and modules for auth, users, hives, tasks, notifications, messaging, media, and auditing
- implement password-hashed registration/login, JWT access tokens, rotating refresh tokens, and role-aware guards
- add transactional services/controllers/repositories for hive/task/media workflows, threaded comments, notifications, and audit logging with admin reporting

## Testing
- `npm install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d035aca62083338755b453e677a2fc