### PR TITLE
feat: align backend with postgres schema and seeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "dev:web": "npm --prefix apps/web run dev",
     "lint": "eslint .",
     "lint:web": "npm --prefix apps/web run lint",
+    "db:migrate": "ts-node src/database/run-migrations.ts",
+    "db:seed": "ts-node src/database/seed.ts",
     "test": "echo 'No automated tests yet'",
     "test:web": "npm --prefix apps/web run test"
   },
@@ -21,9 +23,9 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "jsonwebtoken": "^9.0.0",
+    "pg": "^8.11.3",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.0",
-    "sqlite3": "^5.1.6",
     "typeorm": "^0.3.17"
   },
   "devDependencies": {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,10 +13,21 @@ import { UsersModule } from './users/users.module';
 @Module({
   imports: [
     TypeOrmModule.forRoot({
-      type: 'sqlite',
-      database: 'data/app.sqlite',
+      type: 'postgres',
+      host: process.env.DB_HOST || 'localhost',
+      port: parseInt(process.env.DB_PORT ?? '5432', 10),
+      username: process.env.DB_USERNAME || process.env.DB_USER || 'postgres',
+      password: process.env.DB_PASSWORD || 'postgres',
+      database: process.env.DB_NAME || 'busmedaus',
       autoLoadEntities: true,
-      synchronize: true
+      synchronize: false,
+      migrationsRun: true,
+      migrations: ['dist/migrations/*.js'],
+      migrationsTableName: 'typeorm_migrations',
+      ssl:
+        process.env.DB_SSL === 'true'
+          ? { rejectUnauthorized: process.env.DB_SSL_REJECT_UNAUTHORIZED !== 'false' }
+          : false
     }),
     AuditModule,
     AuthModule,

--- a/src/auth/dto/register.dto.ts
+++ b/src/auth/dto/register.dto.ts
@@ -1,8 +1,34 @@
-import { ArrayNotEmpty, ArrayUnique, IsArray, IsEmail, IsOptional, IsString, MinLength } from 'class-validator';
+import {
+  ArrayNotEmpty,
+  ArrayUnique,
+  IsArray,
+  IsEmail,
+  IsOptional,
+  IsString,
+  MaxLength,
+  MinLength
+} from 'class-validator';
 
 export class RegisterDto {
   @IsEmail()
   email!: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  firstName?: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  lastName?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(32)
+  phoneNumber?: string;
 
   @IsString()
   @MinLength(8)

--- a/src/database/data-source.ts
+++ b/src/database/data-source.ts
@@ -1,0 +1,30 @@
+import { DataSource } from 'typeorm';
+import { User } from '../users/user.entity';
+import { Hive } from '../hives/hive.entity';
+import { Task } from '../tasks/task.entity';
+import { Notification } from '../notifications/notification.entity';
+import { MediaItem } from '../media/media-item.entity';
+import { Comment } from '../messaging/comment.entity';
+import { RefreshToken } from '../auth/refresh-token.entity';
+import { AlignTypeormSchema1700000000000 } from '../migrations/1700000000000-align-typeorm-schema';
+
+const getBoolean = (value: string | undefined, fallback = false): boolean => {
+  if (value === undefined) {
+    return fallback;
+  }
+  return ['1', 'true', 'on', 'yes'].includes(value.toLowerCase());
+};
+
+export const AppDataSource = new DataSource({
+  type: 'postgres',
+  host: process.env.DB_HOST || 'localhost',
+  port: parseInt(process.env.DB_PORT ?? '5432', 10),
+  username: process.env.DB_USERNAME || process.env.DB_USER || 'postgres',
+  password: process.env.DB_PASSWORD || 'postgres',
+  database: process.env.DB_NAME || 'busmedaus',
+  ssl: getBoolean(process.env.DB_SSL) ? { rejectUnauthorized: process.env.DB_SSL_REJECT_UNAUTHORIZED !== 'false' } : false,
+  entities: [User, Hive, Task, Notification, MediaItem, Comment, RefreshToken],
+  migrations: [AlignTypeormSchema1700000000000],
+  migrationsTableName: 'typeorm_migrations',
+  synchronize: false
+});

--- a/src/database/run-migrations.ts
+++ b/src/database/run-migrations.ts
@@ -1,0 +1,17 @@
+import 'reflect-metadata';
+import { AppDataSource } from './data-source';
+
+async function runMigrations() {
+  await AppDataSource.initialize();
+  try {
+    await AppDataSource.runMigrations();
+    console.log('Database migrations executed successfully.');
+  } finally {
+    await AppDataSource.destroy();
+  }
+}
+
+runMigrations().catch((error) => {
+  console.error('Failed to run migrations', error);
+  process.exitCode = 1;
+});

--- a/src/database/seed.ts
+++ b/src/database/seed.ts
@@ -1,0 +1,102 @@
+import 'reflect-metadata';
+import { AppDataSource } from './data-source';
+import { User } from '../users/user.entity';
+import { Hive, HiveStatus } from '../hives/hive.entity';
+import { Task, TaskStatus } from '../tasks/task.entity';
+import { Notification, NotificationChannel, NotificationStatus } from '../notifications/notification.entity';
+import { MediaItem } from '../media/media-item.entity';
+import * as bcrypt from 'bcryptjs';
+
+async function seed() {
+  await AppDataSource.initialize();
+  try {
+    const userRepo = AppDataSource.getRepository(User);
+    let admin = await userRepo.findOne({ where: { email: 'admin@busmedaus.test' } });
+    if (!admin) {
+      admin = userRepo.create({
+        email: 'admin@busmedaus.test',
+        firstName: 'Ava',
+        lastName: 'Nguyen',
+        phoneNumber: '+61-400-000-001',
+        passwordHash: await bcrypt.hash('ChangeMe123!', 12),
+        roles: ['admin'],
+        isActive: true
+      });
+      admin = await userRepo.save(admin);
+    }
+
+    const hiveRepo = AppDataSource.getRepository(Hive);
+    let hive = await hiveRepo.findOne({ where: { name: 'Sunrise' }, relations: ['members', 'owner'] });
+    if (!hive) {
+      hive = hiveRepo.create({
+        name: 'Sunrise',
+        apiaryName: 'Docklands Rooftop',
+        description: 'Primary crew hive',
+        location: 'Docklands, Melbourne VIC',
+        status: HiveStatus.MONITORED,
+        queenStatus: 'Marked 2023 Queen',
+        temperament: 'Calm',
+        healthScore: 85,
+        owner: admin,
+        members: [admin]
+      });
+      hive = await hiveRepo.save(hive);
+    }
+
+    const taskRepo = AppDataSource.getRepository(Task);
+    let task = await taskRepo.findOne({ where: { title: 'Install leveling shims' }, relations: ['hive', 'createdBy'] });
+    if (!task) {
+      task = taskRepo.create({
+        title: 'Install leveling shims',
+        description: 'Stabilize hive stand and add honey super.',
+        status: TaskStatus.IN_PROGRESS,
+        priority: 1,
+        dueDate: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000),
+        hive,
+        createdBy: admin,
+        assignedTo: admin
+      });
+      task = await taskRepo.save(task);
+    }
+
+    const notificationRepo = AppDataSource.getRepository(Notification);
+    const existingNotification = await notificationRepo.findOne({ where: { title: 'Seed task assignment notice' } });
+    if (!existingNotification) {
+      const notification = notificationRepo.create({
+        user: admin,
+        title: 'Seed task assignment notice',
+        body: 'You have been assigned to Install leveling shims.',
+        channel: NotificationChannel.IN_APP,
+        status: NotificationStatus.SENT,
+        relatedTaskId: task.id,
+        metadata: { priority: task.priority },
+        sentAt: new Date()
+      });
+      await notificationRepo.save(notification);
+    }
+
+    const mediaRepo = AppDataSource.getRepository(MediaItem);
+    const existingMedia = await mediaRepo.findOne({ where: { url: 'https://cdn.busmedaus.test/hives/sunrise.jpg' } });
+    if (!existingMedia) {
+      const media = mediaRepo.create({
+        hive,
+        uploader: admin,
+        url: 'https://cdn.busmedaus.test/hives/sunrise.jpg',
+        mimeType: 'image/jpeg',
+        description: 'Top bar photo showing brood pattern.',
+        metadata: { camera: 'SeedScript/1.0' },
+        capturedAt: new Date()
+      });
+      await mediaRepo.save(media);
+    }
+
+    console.log('Database seeding complete.');
+  } finally {
+    await AppDataSource.destroy();
+  }
+}
+
+seed().catch((error) => {
+  console.error('Failed to seed database', error);
+  process.exitCode = 1;
+});

--- a/src/hives/dto/create-hive.dto.ts
+++ b/src/hives/dto/create-hive.dto.ts
@@ -1,4 +1,16 @@
-import { ArrayUnique, IsArray, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+import {
+  ArrayUnique,
+  IsArray,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  MinLength
+} from 'class-validator';
+import { HiveStatus } from '../hive.entity';
 
 export class CreateHiveDto {
   @IsString()
@@ -8,8 +20,38 @@ export class CreateHiveDto {
 
   @IsOptional()
   @IsString()
+  @MaxLength(150)
+  apiaryName?: string;
+
+  @IsOptional()
+  @IsString()
   @MaxLength(500)
   description?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(300)
+  location?: string;
+
+  @IsOptional()
+  @IsEnum(HiveStatus)
+  status?: HiveStatus;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  queenStatus?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  temperament?: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(100)
+  healthScore?: number;
 
   @IsOptional()
   @IsArray()

--- a/src/hives/dto/manage-hive-member.dto.ts
+++ b/src/hives/dto/manage-hive-member.dto.ts
@@ -1,7 +1,7 @@
-import { IsString, IsUUID } from 'class-validator';
+import { IsString, MinLength } from 'class-validator';
 
 export class ManageHiveMemberDto {
   @IsString()
-  @IsUUID()
+  @MinLength(1)
   userId!: string;
 }

--- a/src/hives/dto/update-hive.dto.ts
+++ b/src/hives/dto/update-hive.dto.ts
@@ -1,4 +1,16 @@
-import { ArrayUnique, IsArray, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+import {
+  ArrayUnique,
+  IsArray,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  MinLength
+} from 'class-validator';
+import { HiveStatus } from '../hive.entity';
 
 export class UpdateHiveDto {
   @IsOptional()
@@ -11,6 +23,36 @@ export class UpdateHiveDto {
   @IsString()
   @MaxLength(500)
   description?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(150)
+  apiaryName?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(300)
+  location?: string;
+
+  @IsOptional()
+  @IsEnum(HiveStatus)
+  status?: HiveStatus;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  queenStatus?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  temperament?: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(100)
+  healthScore?: number;
 
   @IsOptional()
   @IsArray()

--- a/src/hives/hive.entity.ts
+++ b/src/hives/hive.entity.ts
@@ -13,6 +13,13 @@ import { User } from '../users/user.entity';
 import { Task } from '../tasks/task.entity';
 import { MediaItem } from '../media/media-item.entity';
 
+export enum HiveStatus {
+  ACTIVE = 'ACTIVE',
+  MONITORED = 'MONITORED',
+  INACTIVE = 'INACTIVE',
+  NEEDS_ATTENTION = 'NEEDS_ATTENTION'
+}
+
 @Entity({ name: 'hives' })
 export class Hive {
   @PrimaryGeneratedColumn('uuid')
@@ -21,8 +28,26 @@ export class Hive {
   @Column()
   name!: string;
 
+  @Column({ default: '' })
+  apiaryName!: string;
+
   @Column({ nullable: true })
   description?: string;
+
+  @Column({ nullable: true })
+  location?: string;
+
+  @Column({ type: 'text', default: HiveStatus.ACTIVE })
+  status!: HiveStatus;
+
+  @Column({ nullable: true })
+  queenStatus?: string;
+
+  @Column({ nullable: true })
+  temperament?: string;
+
+  @Column({ type: 'smallint', nullable: true })
+  healthScore?: number;
 
   @ManyToOne(() => User, (user) => user.ownedHives, { eager: true, onDelete: 'SET NULL' })
   owner!: User;

--- a/src/hives/hives.service.ts
+++ b/src/hives/hives.service.ts
@@ -6,7 +6,7 @@ import { UsersService } from '../users/users.service';
 import { CreateHiveDto } from './dto/create-hive.dto';
 import { ManageHiveMemberDto } from './dto/manage-hive-member.dto';
 import { UpdateHiveDto } from './dto/update-hive.dto';
-import { Hive } from './hive.entity';
+import { Hive, HiveStatus } from './hive.entity';
 import { HivesRepository } from './hives.repository';
 
 @Injectable()
@@ -59,7 +59,13 @@ export class HivesService {
       const hiveEntity = this.hivesRepository.create(
         {
           name: dto.name,
+          apiaryName: dto.apiaryName ?? dto.name,
           description: dto.description,
+          location: dto.location,
+          status: dto.status ?? HiveStatus.ACTIVE,
+          queenStatus: dto.queenStatus,
+          temperament: dto.temperament,
+          healthScore: dto.healthScore,
           owner,
           members: Array.from(uniqueMembers.values())
         },
@@ -71,8 +77,10 @@ export class HivesService {
 
     const memberIds = hive.members.filter((member) => member.id !== user.userId).map((member) => member.id);
     if (memberIds.length) {
-      await this.notificationsService.notifyUsers(memberIds, `${user.email} added you to hive ${hive.name}`, {
-        hiveId: hive.id
+      await this.notificationsService.notifyUsers(memberIds, {
+        title: `You were added to hive ${hive.name}`,
+        body: `${user.email} added you to hive ${hive.name}.`,
+        metadata: { hiveId: hive.id }
       });
     }
 
@@ -91,8 +99,26 @@ export class HivesService {
       if (dto.name) {
         hiveEntity.name = dto.name;
       }
+      if (dto.apiaryName !== undefined) {
+        hiveEntity.apiaryName = dto.apiaryName;
+      }
       if (dto.description !== undefined) {
         hiveEntity.description = dto.description;
+      }
+      if (dto.location !== undefined) {
+        hiveEntity.location = dto.location;
+      }
+      if (dto.status !== undefined) {
+        hiveEntity.status = dto.status;
+      }
+      if (dto.queenStatus !== undefined) {
+        hiveEntity.queenStatus = dto.queenStatus;
+      }
+      if (dto.temperament !== undefined) {
+        hiveEntity.temperament = dto.temperament;
+      }
+      if (dto.healthScore !== undefined) {
+        hiveEntity.healthScore = dto.healthScore;
       }
       if (dto.memberIds) {
         const members = [];
@@ -110,8 +136,11 @@ export class HivesService {
 
     await this.notificationsService.notifyUsers(
       hive.members.map((member) => member.id),
-      `Hive ${hive.name} was updated`,
-      { hiveId: hive.id }
+      {
+        title: `Hive ${hive.name} was updated`,
+        body: `Hive ${hive.name} details were updated.`,
+        metadata: { hiveId: hive.id }
+      }
     );
 
     return hive;
@@ -144,8 +173,10 @@ export class HivesService {
       return this.hivesRepository.save(hiveEntity, manager);
     });
 
-    await this.notificationsService.notifyUsers([dto.userId], `You were added to hive ${hive.name}`, {
-      hiveId: hive.id
+    await this.notificationsService.notifyUsers([dto.userId], {
+      title: `You were added to hive ${hive.name}`,
+      body: `${user.email} added you to hive ${hive.name}.`,
+      metadata: { hiveId: hive.id }
     });
 
     return hive;
@@ -167,8 +198,10 @@ export class HivesService {
       return this.hivesRepository.save(hiveEntity, manager);
     });
 
-    await this.notificationsService.notifyUsers([memberId], `You were removed from hive ${hive.name}`, {
-      hiveId: hive.id
+    await this.notificationsService.notifyUsers([memberId], {
+      title: `You were removed from hive ${hive.name}`,
+      body: `${user.email} removed you from hive ${hive.name}.`,
+      metadata: { hiveId: hive.id }
     });
 
     return hive;

--- a/src/media/dto/create-media-item.dto.ts
+++ b/src/media/dto/create-media-item.dto.ts
@@ -1,16 +1,16 @@
-import { IsOptional, IsString, IsUrl, IsUUID, MaxLength } from 'class-validator';
+import { IsDateString, IsOptional, IsString, IsUrl, MaxLength, MinLength } from 'class-validator';
 
 export class CreateMediaItemDto {
-  @IsUUID()
+  @IsString()
+  @MinLength(1)
   hiveId!: string;
 
   @IsUrl()
   url!: string;
 
-  @IsOptional()
   @IsString()
-  @MaxLength(100)
-  type?: string;
+  @MaxLength(150)
+  mimeType!: string;
 
   @IsOptional()
   @IsString()
@@ -18,6 +18,29 @@ export class CreateMediaItemDto {
   description?: string;
 
   @IsOptional()
+  metadata?: Record<string, unknown>;
+
+  @IsOptional()
   @IsString()
-  metadata?: string;
+  @MinLength(1)
+  inspectionId?: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  taskId?: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  harvestId?: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  auditEventId?: string;
+
+  @IsOptional()
+  @IsDateString()
+  capturedAt?: string;
 }

--- a/src/media/dto/update-media-item.dto.ts
+++ b/src/media/dto/update-media-item.dto.ts
@@ -1,10 +1,10 @@
-import { IsOptional, IsString, MaxLength } from 'class-validator';
+import { IsDateString, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
 
 export class UpdateMediaItemDto {
   @IsOptional()
   @IsString()
-  @MaxLength(100)
-  type?: string;
+  @MaxLength(150)
+  mimeType?: string;
 
   @IsOptional()
   @IsString()
@@ -12,6 +12,29 @@ export class UpdateMediaItemDto {
   description?: string;
 
   @IsOptional()
+  metadata?: Record<string, unknown>;
+
+  @IsOptional()
   @IsString()
-  metadata?: string;
+  @MinLength(1)
+  inspectionId?: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  taskId?: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  harvestId?: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  auditEventId?: string;
+
+  @IsOptional()
+  @IsDateString()
+  capturedAt?: string;
 }

--- a/src/media/media-item.entity.ts
+++ b/src/media/media-item.entity.ts
@@ -2,6 +2,7 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
   UpdateDateColumn
@@ -17,20 +18,37 @@ export class MediaItem {
   @Column()
   url!: string;
 
-  @Column({ nullable: true })
-  type?: string;
+  @Column()
+  mimeType!: string;
 
   @Column({ nullable: true })
   description?: string;
 
-  @Column({ nullable: true })
-  metadata?: string;
+  @Column({ type: 'simple-json', nullable: true })
+  metadata?: Record<string, unknown> | null;
 
   @ManyToOne(() => Hive, (hive) => hive.mediaItems, { onDelete: 'CASCADE', eager: true })
+  @JoinColumn({ name: 'hiveId' })
   hive!: Hive;
 
+  @Column({ nullable: true })
+  inspectionId?: string;
+
+  @Column({ nullable: true })
+  taskId?: string;
+
+  @Column({ nullable: true })
+  harvestId?: string;
+
+  @Column({ nullable: true })
+  auditEventId?: string;
+
   @ManyToOne(() => User, (user) => user.mediaItems, { eager: true })
+  @JoinColumn({ name: 'uploaderId' })
   uploader!: User;
+
+  @Column({ type: 'datetime', nullable: true })
+  capturedAt?: Date;
 
   @CreateDateColumn()
   createdAt!: Date;

--- a/src/media/media.controller.ts
+++ b/src/media/media.controller.ts
@@ -10,9 +10,14 @@ import { MediaService } from './media.service';
 interface MediaResponse {
   id: string;
   url: string;
-  type?: string;
+  mimeType: string;
   description?: string;
-  metadata?: string | null;
+  metadata?: Record<string, unknown> | null;
+  inspectionId?: string;
+  taskId?: string;
+  harvestId?: string;
+  auditEventId?: string;
+  capturedAt?: Date | null;
   hive: { id: string; name: string };
   uploader: { id: string; email: string };
   createdAt: Date;
@@ -23,9 +28,14 @@ function mapMedia(item: MediaItem): MediaResponse {
   return {
     id: item.id,
     url: item.url,
-    type: item.type,
+    mimeType: item.mimeType,
     description: item.description,
     metadata: item.metadata ?? null,
+    inspectionId: item.inspectionId ?? undefined,
+    taskId: item.taskId ?? undefined,
+    harvestId: item.harvestId ?? undefined,
+    auditEventId: item.auditEventId ?? undefined,
+    capturedAt: item.capturedAt ?? null,
     hive: { id: item.hive.id, name: item.hive.name },
     uploader: { id: item.uploader.id, email: item.uploader.email },
     createdAt: item.createdAt,

--- a/src/media/media.service.ts
+++ b/src/media/media.service.ts
@@ -46,9 +46,14 @@ export class MediaService {
           hive,
           uploader,
           url: dto.url,
-          type: dto.type,
+          mimeType: dto.mimeType,
           description: dto.description,
-          metadata: dto.metadata
+          metadata: dto.metadata ?? null,
+          inspectionId: dto.inspectionId,
+          taskId: dto.taskId,
+          harvestId: dto.harvestId,
+          auditEventId: dto.auditEventId,
+          capturedAt: dto.capturedAt ? new Date(dto.capturedAt) : undefined
         },
         manager
       );
@@ -61,9 +66,10 @@ export class MediaService {
     recipients.delete(user.userId);
 
     if (recipients.size) {
-      await this.notificationsService.notifyUsers(Array.from(recipients), `New media added to ${media.hive.name}`, {
-        mediaId: media.id,
-        hiveId: media.hive.id
+      await this.notificationsService.notifyUsers(Array.from(recipients), {
+        title: `New media added to ${media.hive.name}`,
+        body: `${user.email} uploaded new media to ${media.hive.name}.`,
+        metadata: { mediaId: media.id, hiveId: media.hive.id }
       });
     }
 
@@ -78,14 +84,34 @@ export class MediaService {
       }
       this.ensureMediaManageAccess(user, mediaEntity);
 
-      if (dto.type !== undefined) {
-        mediaEntity.type = dto.type;
+      if (dto.mimeType !== undefined) {
+        mediaEntity.mimeType = dto.mimeType;
       }
       if (dto.description !== undefined) {
         mediaEntity.description = dto.description;
       }
       if (dto.metadata !== undefined) {
         mediaEntity.metadata = dto.metadata;
+      }
+
+      if (dto.inspectionId !== undefined) {
+        mediaEntity.inspectionId = dto.inspectionId || undefined;
+      }
+
+      if (dto.taskId !== undefined) {
+        mediaEntity.taskId = dto.taskId || undefined;
+      }
+
+      if (dto.harvestId !== undefined) {
+        mediaEntity.harvestId = dto.harvestId || undefined;
+      }
+
+      if (dto.auditEventId !== undefined) {
+        mediaEntity.auditEventId = dto.auditEventId || undefined;
+      }
+
+      if (dto.capturedAt !== undefined) {
+        mediaEntity.capturedAt = dto.capturedAt ? new Date(dto.capturedAt) : undefined;
       }
 
       return this.mediaRepository.save(mediaEntity, manager);

--- a/src/messaging/messaging.service.ts
+++ b/src/messaging/messaging.service.ts
@@ -64,10 +64,10 @@ export class MessagingService {
     });
 
     if (recipients.length) {
-      await this.notificationsService.notifyUsers(recipients, `New comment on task ${comment.task.title}`, {
-        taskId: comment.task.id,
-        hiveId: comment.task.hive.id,
-        commentId: comment.id
+      await this.notificationsService.notifyUsers(recipients, {
+        title: `New comment on task ${comment.task.title}`,
+        body: `${user.email} commented on ${comment.task.title}.`,
+        metadata: { taskId: comment.task.id, hiveId: comment.task.hive.id, commentId: comment.id }
       });
     }
 

--- a/src/migrations/1700000000000-align-typeorm-schema.ts
+++ b/src/migrations/1700000000000-align-typeorm-schema.ts
@@ -1,0 +1,96 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AlignTypeormSchema1700000000000 implements MigrationInterface {
+  name = 'AlignTypeormSchema1700000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "firstName" character varying(100) NOT NULL DEFAULT ''`);
+    await queryRunner.query(`ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "lastName" character varying(100) NOT NULL DEFAULT ''`);
+    await queryRunner.query(`ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "phoneNumber" character varying(32)`);
+
+    await queryRunner.query(`ALTER TABLE "hives" ADD COLUMN IF NOT EXISTS "apiaryName" character varying(150) NOT NULL DEFAULT ''`);
+    await queryRunner.query(`ALTER TABLE "hives" ADD COLUMN IF NOT EXISTS "location" character varying(300)`);
+    await queryRunner.query(`ALTER TABLE "hives" ADD COLUMN IF NOT EXISTS "status" text NOT NULL DEFAULT 'ACTIVE'`);
+    await queryRunner.query(`ALTER TABLE "hives" ADD COLUMN IF NOT EXISTS "queenStatus" character varying(200)`);
+    await queryRunner.query(`ALTER TABLE "hives" ADD COLUMN IF NOT EXISTS "temperament" character varying(200)`);
+    await queryRunner.query(`ALTER TABLE "hives" ADD COLUMN IF NOT EXISTS "healthScore" smallint`);
+
+    await queryRunner.query(`ALTER TABLE "tasks" ADD COLUMN IF NOT EXISTS "priority" integer NOT NULL DEFAULT 2`);
+    await queryRunner.query(`ALTER TABLE "tasks" ADD COLUMN IF NOT EXISTS "dueDate" TIMESTAMP`);
+    await queryRunner.query(`ALTER TABLE "tasks" ADD COLUMN IF NOT EXISTS "inspectionId" text`);
+    await queryRunner.query(`ALTER TABLE "tasks" ADD COLUMN IF NOT EXISTS "templateId" text`);
+    await queryRunner.query(`ALTER TABLE "tasks" ADD COLUMN IF NOT EXISTS "createdById" text`);
+    await queryRunner.query(
+      `ALTER TABLE "tasks" ADD CONSTRAINT IF NOT EXISTS "FK_tasks_createdBy" FOREIGN KEY ("createdById") REFERENCES "users"("id") ON DELETE SET NULL`
+    );
+
+    await queryRunner.query(`ALTER TABLE "notifications" DROP COLUMN IF EXISTS "message"`);
+    await queryRunner.query(`ALTER TABLE "notifications" DROP COLUMN IF EXISTS "read"`);
+    await queryRunner.query(`ALTER TABLE "notifications" DROP COLUMN IF EXISTS "metadata"`);
+    await queryRunner.query(`ALTER TABLE "notifications" ADD COLUMN IF NOT EXISTS "channel" text NOT NULL DEFAULT 'IN_APP'`);
+    await queryRunner.query(`ALTER TABLE "notifications" ADD COLUMN IF NOT EXISTS "status" text NOT NULL DEFAULT 'PENDING'`);
+    await queryRunner.query(`ALTER TABLE "notifications" ADD COLUMN IF NOT EXISTS "title" text NOT NULL DEFAULT ''`);
+    await queryRunner.query(`ALTER TABLE "notifications" ADD COLUMN IF NOT EXISTS "body" text NOT NULL DEFAULT ''`);
+    await queryRunner.query(`ALTER TABLE "notifications" ADD COLUMN IF NOT EXISTS "relatedTaskId" text`);
+    await queryRunner.query(`ALTER TABLE "notifications" ADD COLUMN IF NOT EXISTS "relatedInspectionId" text`);
+    await queryRunner.query(`ALTER TABLE "notifications" ADD COLUMN IF NOT EXISTS "relatedHarvestId" text`);
+    await queryRunner.query(`ALTER TABLE "notifications" ADD COLUMN IF NOT EXISTS "auditEventId" text`);
+    await queryRunner.query(`ALTER TABLE "notifications" ADD COLUMN IF NOT EXISTS "metadata" jsonb`);
+    await queryRunner.query(`ALTER TABLE "notifications" ADD COLUMN IF NOT EXISTS "sentAt" TIMESTAMP`);
+    await queryRunner.query(`ALTER TABLE "notifications" ADD COLUMN IF NOT EXISTS "readAt" TIMESTAMP`);
+
+    await queryRunner.query(`ALTER TABLE "media_items" DROP COLUMN IF EXISTS "type"`);
+    await queryRunner.query(`ALTER TABLE "media_items" DROP COLUMN IF EXISTS "metadata"`);
+    await queryRunner.query(`ALTER TABLE "media_items" ADD COLUMN IF NOT EXISTS "mimeType" character varying(150) NOT NULL DEFAULT ''`);
+    await queryRunner.query(`ALTER TABLE "media_items" ADD COLUMN IF NOT EXISTS "metadata" jsonb`);
+    await queryRunner.query(`ALTER TABLE "media_items" ADD COLUMN IF NOT EXISTS "inspectionId" text`);
+    await queryRunner.query(`ALTER TABLE "media_items" ADD COLUMN IF NOT EXISTS "taskId" text`);
+    await queryRunner.query(`ALTER TABLE "media_items" ADD COLUMN IF NOT EXISTS "harvestId" text`);
+    await queryRunner.query(`ALTER TABLE "media_items" ADD COLUMN IF NOT EXISTS "auditEventId" text`);
+    await queryRunner.query(`ALTER TABLE "media_items" ADD COLUMN IF NOT EXISTS "capturedAt" TIMESTAMP`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "media_items" DROP COLUMN IF EXISTS "capturedAt"`);
+    await queryRunner.query(`ALTER TABLE "media_items" DROP COLUMN IF EXISTS "auditEventId"`);
+    await queryRunner.query(`ALTER TABLE "media_items" DROP COLUMN IF EXISTS "harvestId"`);
+    await queryRunner.query(`ALTER TABLE "media_items" DROP COLUMN IF EXISTS "taskId"`);
+    await queryRunner.query(`ALTER TABLE "media_items" DROP COLUMN IF EXISTS "inspectionId"`);
+    await queryRunner.query(`ALTER TABLE "media_items" DROP COLUMN IF EXISTS "metadata"`);
+    await queryRunner.query(`ALTER TABLE "media_items" DROP COLUMN IF EXISTS "mimeType"`);
+    await queryRunner.query(`ALTER TABLE "media_items" ADD COLUMN IF NOT EXISTS "metadata" text`);
+    await queryRunner.query(`ALTER TABLE "media_items" ADD COLUMN IF NOT EXISTS "type" character varying(100)`);
+
+    await queryRunner.query(`ALTER TABLE "notifications" DROP COLUMN IF EXISTS "readAt"`);
+    await queryRunner.query(`ALTER TABLE "notifications" DROP COLUMN IF EXISTS "sentAt"`);
+    await queryRunner.query(`ALTER TABLE "notifications" DROP COLUMN IF EXISTS "metadata"`);
+    await queryRunner.query(`ALTER TABLE "notifications" DROP COLUMN IF EXISTS "auditEventId"`);
+    await queryRunner.query(`ALTER TABLE "notifications" DROP COLUMN IF EXISTS "relatedHarvestId"`);
+    await queryRunner.query(`ALTER TABLE "notifications" DROP COLUMN IF EXISTS "relatedInspectionId"`);
+    await queryRunner.query(`ALTER TABLE "notifications" DROP COLUMN IF EXISTS "relatedTaskId"`);
+    await queryRunner.query(`ALTER TABLE "notifications" DROP COLUMN IF EXISTS "body"`);
+    await queryRunner.query(`ALTER TABLE "notifications" DROP COLUMN IF EXISTS "title"`);
+    await queryRunner.query(`ALTER TABLE "notifications" DROP COLUMN IF EXISTS "status"`);
+    await queryRunner.query(`ALTER TABLE "notifications" DROP COLUMN IF EXISTS "channel"`);
+    await queryRunner.query(`ALTER TABLE "notifications" ADD COLUMN IF NOT EXISTS "metadata" text`);
+    await queryRunner.query(`ALTER TABLE "notifications" ADD COLUMN IF NOT EXISTS "message" text`);
+    await queryRunner.query(`ALTER TABLE "notifications" ADD COLUMN IF NOT EXISTS "read" boolean NOT NULL DEFAULT false`);
+
+    await queryRunner.query(`ALTER TABLE "tasks" DROP COLUMN IF EXISTS "createdById"`);
+    await queryRunner.query(`ALTER TABLE "tasks" DROP COLUMN IF EXISTS "templateId"`);
+    await queryRunner.query(`ALTER TABLE "tasks" DROP COLUMN IF EXISTS "inspectionId"`);
+    await queryRunner.query(`ALTER TABLE "tasks" DROP COLUMN IF EXISTS "dueDate"`);
+    await queryRunner.query(`ALTER TABLE "tasks" DROP COLUMN IF EXISTS "priority"`);
+
+    await queryRunner.query(`ALTER TABLE "hives" DROP COLUMN IF EXISTS "healthScore"`);
+    await queryRunner.query(`ALTER TABLE "hives" DROP COLUMN IF EXISTS "temperament"`);
+    await queryRunner.query(`ALTER TABLE "hives" DROP COLUMN IF EXISTS "queenStatus"`);
+    await queryRunner.query(`ALTER TABLE "hives" DROP COLUMN IF EXISTS "status"`);
+    await queryRunner.query(`ALTER TABLE "hives" DROP COLUMN IF EXISTS "location"`);
+    await queryRunner.query(`ALTER TABLE "hives" DROP COLUMN IF EXISTS "apiaryName"`);
+
+    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN IF EXISTS "phoneNumber"`);
+    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN IF EXISTS "lastName"`);
+    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN IF EXISTS "firstName"`);
+  }
+}

--- a/src/notifications/notification.entity.ts
+++ b/src/notifications/notification.entity.ts
@@ -2,11 +2,25 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
   UpdateDateColumn
 } from 'typeorm';
 import { User } from '../users/user.entity';
+
+export enum NotificationChannel {
+  IN_APP = 'IN_APP',
+  EMAIL = 'EMAIL',
+  SMS = 'SMS'
+}
+
+export enum NotificationStatus {
+  PENDING = 'PENDING',
+  SENT = 'SENT',
+  FAILED = 'FAILED',
+  READ = 'READ'
+}
 
 @Entity({ name: 'notifications' })
 export class Notification {
@@ -14,16 +28,41 @@ export class Notification {
   id!: string;
 
   @ManyToOne(() => User, (user) => user.notifications, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
   user!: User;
 
-  @Column('text')
-  message!: string;
+  @Column({ type: 'text', default: NotificationChannel.IN_APP })
+  channel!: NotificationChannel;
 
-  @Column({ default: false })
-  read!: boolean;
+  @Column({ type: 'text', default: NotificationStatus.PENDING })
+  status!: NotificationStatus;
+
+  @Column()
+  title!: string;
+
+  @Column('text')
+  body!: string;
 
   @Column({ nullable: true })
-  metadata?: string;
+  relatedTaskId?: string;
+
+  @Column({ nullable: true })
+  relatedInspectionId?: string;
+
+  @Column({ nullable: true })
+  relatedHarvestId?: string;
+
+  @Column({ nullable: true })
+  auditEventId?: string;
+
+  @Column({ type: 'simple-json', nullable: true })
+  metadata?: Record<string, unknown> | null;
+
+  @Column({ type: 'datetime', nullable: true })
+  sentAt?: Date;
+
+  @Column({ type: 'datetime', nullable: true })
+  readAt?: Date;
 
   @CreateDateColumn()
   createdAt!: Date;

--- a/src/notifications/notifications.controller.ts
+++ b/src/notifications/notifications.controller.ts
@@ -7,9 +7,17 @@ import { NotificationsService } from './notifications.service';
 
 interface NotificationResponse {
   id: string;
-  message: string;
+  title: string;
+  body: string;
+  channel: string;
+  status: string;
   metadata?: Record<string, unknown> | null;
-  read: boolean;
+  relatedTaskId?: string;
+  relatedInspectionId?: string;
+  relatedHarvestId?: string;
+  auditEventId?: string;
+  sentAt?: Date | null;
+  readAt?: Date | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -17,9 +25,17 @@ interface NotificationResponse {
 function mapNotification(notification: Notification): NotificationResponse {
   return {
     id: notification.id,
-    message: notification.message,
-    metadata: notification.metadata ? JSON.parse(notification.metadata) : null,
-    read: notification.read,
+    title: notification.title,
+    body: notification.body,
+    channel: notification.channel,
+    status: notification.status,
+    metadata: notification.metadata ?? null,
+    relatedTaskId: notification.relatedTaskId ?? undefined,
+    relatedInspectionId: notification.relatedInspectionId ?? undefined,
+    relatedHarvestId: notification.relatedHarvestId ?? undefined,
+    auditEventId: notification.auditEventId ?? undefined,
+    sentAt: notification.sentAt ?? null,
+    readAt: notification.readAt ?? null,
     createdAt: notification.createdAt,
     updatedAt: notification.updatedAt
   };

--- a/src/tasks/dto/create-task.dto.ts
+++ b/src/tasks/dto/create-task.dto.ts
@@ -1,8 +1,19 @@
-import { IsEnum, IsOptional, IsString, IsUUID, MaxLength, MinLength } from 'class-validator';
+import {
+  IsDateString,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  MinLength
+} from 'class-validator';
 import { TaskStatus } from '../task-status.enum';
 
 export class CreateTaskDto {
-  @IsUUID()
+  @IsString()
+  @MinLength(1)
   hiveId!: string;
 
   @IsString()
@@ -16,10 +27,31 @@ export class CreateTaskDto {
   description?: string;
 
   @IsOptional()
-  @IsUUID()
+  @IsString()
+  @MinLength(1)
   assignedToId?: string;
 
   @IsOptional()
   @IsEnum(TaskStatus)
   status?: TaskStatus;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(5)
+  priority?: number;
+
+  @IsOptional()
+  @IsDateString()
+  dueDate?: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  inspectionId?: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  templateId?: string;
 }

--- a/src/tasks/dto/update-task.dto.ts
+++ b/src/tasks/dto/update-task.dto.ts
@@ -1,4 +1,15 @@
-import { IsBoolean, IsEnum, IsOptional, IsString, IsUUID, MaxLength, MinLength } from 'class-validator';
+import {
+  IsBoolean,
+  IsDateString,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  MinLength
+} from 'class-validator';
 import { TaskStatus } from '../task-status.enum';
 
 export class UpdateTaskDto {
@@ -14,7 +25,8 @@ export class UpdateTaskDto {
   description?: string;
 
   @IsOptional()
-  @IsUUID()
+  @IsString()
+  @MinLength(1)
   assignedToId?: string;
 
   @IsOptional()
@@ -24,4 +36,24 @@ export class UpdateTaskDto {
   @IsOptional()
   @IsBoolean()
   unassign?: boolean;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(5)
+  priority?: number;
+
+  @IsOptional()
+  @IsDateString()
+  dueDate?: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  inspectionId?: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  templateId?: string;
 }

--- a/src/tasks/task-status.enum.ts
+++ b/src/tasks/task-status.enum.ts
@@ -1,6 +1,7 @@
 export enum TaskStatus {
-  TODO = 'todo',
-  IN_PROGRESS = 'in_progress',
-  REVIEW = 'review',
-  DONE = 'done'
+  PENDING = 'PENDING',
+  IN_PROGRESS = 'IN_PROGRESS',
+  COMPLETED = 'COMPLETED',
+  BLOCKED = 'BLOCKED',
+  CANCELLED = 'CANCELLED'
 }

--- a/src/tasks/task.entity.ts
+++ b/src/tasks/task.entity.ts
@@ -2,6 +2,7 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  JoinColumn,
   ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
@@ -23,13 +24,30 @@ export class Task {
   @Column({ nullable: true })
   description?: string;
 
-  @Column({ type: 'text', default: TaskStatus.TODO })
+  @Column({ type: 'text', default: TaskStatus.PENDING })
   status!: TaskStatus;
+
+  @Column({ type: 'int', default: 2 })
+  priority!: number;
+
+  @Column({ type: 'timestamp', nullable: true })
+  dueDate?: Date;
 
   @ManyToOne(() => Hive, (hive) => hive.tasks, { onDelete: 'CASCADE', eager: true })
   hive!: Hive;
 
+  @Column({ nullable: true })
+  inspectionId?: string;
+
+  @Column({ nullable: true })
+  templateId?: string;
+
+  @ManyToOne(() => User, (user) => user.tasksCreated, { eager: true })
+  @JoinColumn({ name: 'createdById' })
+  createdBy!: User;
+
   @ManyToOne(() => User, (user) => user.assignedTasks, { nullable: true, eager: true })
+  @JoinColumn({ name: 'assignedToId' })
   assignedTo?: User | null;
 
   @OneToMany(() => Comment, (comment) => comment.task)

--- a/src/tasks/tasks.controller.ts
+++ b/src/tasks/tasks.controller.ts
@@ -24,8 +24,13 @@ interface TaskResponse {
   title: string;
   description?: string;
   status: string;
+  priority: number;
+  dueDate?: Date | null;
+  inspectionId?: string;
+  templateId?: string;
   hive: TaskHiveSummary;
   assignedTo?: TaskUserSummary | null;
+  createdBy: TaskUserSummary;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -43,8 +48,13 @@ function mapTask(task: Task): TaskResponse {
     title: task.title,
     description: task.description,
     status: task.status,
+    priority: task.priority,
+    dueDate: task.dueDate ?? null,
+    inspectionId: task.inspectionId ?? undefined,
+    templateId: task.templateId ?? undefined,
     hive: { id: task.hive.id, name: task.hive.name },
     assignedTo: mapUser(task.assignedTo),
+    createdBy: mapUser(task.createdBy)!,
     createdAt: task.createdAt,
     updatedAt: task.updatedAt
   };

--- a/src/tasks/tasks.repository.ts
+++ b/src/tasks/tasks.repository.ts
@@ -25,7 +25,7 @@ export class TasksRepository {
   findById(id: string, manager?: EntityManager): Promise<Task | null> {
     return this.getRepo(manager).findOne({
       where: { id },
-      relations: ['hive', 'assignedTo', 'hive.owner', 'hive.members']
+      relations: ['hive', 'assignedTo', 'createdBy', 'hive.owner', 'hive.members']
     });
   }
 
@@ -36,7 +36,7 @@ export class TasksRepository {
   findByHive(hiveId: string): Promise<Task[]> {
     return this.repository.find({
       where: { hive: { id: hiveId } },
-      relations: ['hive', 'assignedTo'],
+      relations: ['hive', 'assignedTo', 'createdBy'],
       order: { createdAt: 'DESC' }
     });
   }

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -1,8 +1,34 @@
-import { ArrayNotEmpty, ArrayUnique, IsArray, IsEmail, IsOptional, IsString, MinLength } from 'class-validator';
+import {
+  ArrayNotEmpty,
+  ArrayUnique,
+  IsArray,
+  IsEmail,
+  IsOptional,
+  IsString,
+  MaxLength,
+  MinLength
+} from 'class-validator';
 
 export class CreateUserDto {
   @IsEmail()
   email!: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  firstName?: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  lastName?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(32)
+  phoneNumber?: string;
 
   @IsString()
   @MinLength(8)

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -1,6 +1,23 @@
-import { ArrayUnique, IsArray, IsBoolean, IsOptional, IsString } from 'class-validator';
+import { ArrayUnique, IsArray, IsBoolean, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
 
 export class UpdateUserDto {
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  firstName?: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  lastName?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(32)
+  phoneNumber?: string;
+
   @IsOptional()
   @IsArray()
   @ArrayUnique()

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -23,6 +23,15 @@ export class User {
   @Column({ unique: true })
   email!: string;
 
+  @Column({ default: '' })
+  firstName!: string;
+
+  @Column({ default: '' })
+  lastName!: string;
+
+  @Column({ nullable: true })
+  phoneNumber?: string | null;
+
   @Column()
   passwordHash!: string;
 
@@ -47,6 +56,9 @@ export class User {
 
   @OneToMany(() => Task, (task) => task.assignedTo)
   assignedTasks!: Task[];
+
+  @OneToMany(() => Task, (task) => task.createdBy)
+  createdTasks!: Task[];
 
   @OneToMany(() => Notification, (notification) => notification.user)
   notifications!: Notification[];

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -11,6 +11,9 @@ import { User } from './user.entity';
 interface SafeUser {
   id: string;
   email: string;
+  firstName: string;
+  lastName: string;
+  phoneNumber: string | null;
   roles: string[];
   isActive: boolean;
   createdAt: Date;
@@ -18,8 +21,8 @@ interface SafeUser {
 }
 
 function toSafeUser(user: User): SafeUser {
-  const { id, email, roles, isActive, createdAt, updatedAt } = user;
-  return { id, email, roles, isActive, createdAt, updatedAt };
+  const { id, email, firstName, lastName, phoneNumber, roles, isActive, createdAt, updatedAt } = user;
+  return { id, email, firstName, lastName, phoneNumber: phoneNumber ?? null, roles, isActive, createdAt, updatedAt };
 }
 
 @Controller('users')

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -19,6 +19,9 @@ export class UsersService {
     const passwordHash = await bcrypt.hash(dto.password, 12);
     const user = this.usersRepository.create({
       email: dto.email.toLowerCase(),
+      firstName: dto.firstName?.trim() || '',
+      lastName: dto.lastName?.trim() || '',
+      phoneNumber: dto.phoneNumber?.trim() ?? null,
       passwordHash,
       roles: dto.roles?.length ? dto.roles : ['member'],
       isActive: true
@@ -46,6 +49,18 @@ export class UsersService {
 
   async updateUser(id: string, dto: UpdateUserDto, manager?: EntityManager): Promise<User> {
     const user = await this.findByIdOrFail(id, manager);
+
+    if (dto.firstName !== undefined) {
+      user.firstName = dto.firstName.trim();
+    }
+
+    if (dto.lastName !== undefined) {
+      user.lastName = dto.lastName.trim();
+    }
+
+    if (dto.phoneNumber !== undefined) {
+      user.phoneNumber = dto.phoneNumber?.trim() ?? null;
+    }
 
     if (dto.roles) {
       if (!dto.roles.length) {


### PR DESCRIPTION
## Summary
- switch the NestJS TypeORM bootstrap to use environment-driven PostgreSQL settings and add scripts for running migrations and seed data
- expand user, hive, task, notification, and media entities plus their DTOs/controllers to cover the Prisma schema fields and new enum values
- introduce a repeatable migration alongside TypeORM-based migration/seed runners for shared database initialization

## Testing
- npm run lint *(fails: repository still uses legacy ESLint config format)*
- npm run build *(fails: front-end dependencies such as vite/tailwind are unavailable in the execution environment)*


------
https://chatgpt.com/codex/tasks/task_e_68d046123298833391ae018ae7a5bcd2