### PR TITLE
Add backend testing and CI pipeline

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,5 +16,18 @@
   "rules": {
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }]
-  }
+  },
+  "overrides": [
+    {
+      "files": [
+        "src/**/*.spec.ts",
+        "src/**/*.test.ts",
+        "src/**/__tests__/**/*.ts"
+      ],
+      "env": {
+        "jest": true,
+        "node": true
+      }
+    }
+  ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - 'release/**'
+      - 'feature/**'
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install backend dependencies
+        run: npm install
+
+      - name: Install web dependencies
+        run: npm install
+        working-directory: apps/web
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build service
+        run: npm run build
+
+  docker:
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+
+COPY package*.json ./
+COPY tsconfig.json ./
+COPY .eslintrc.json ./
+COPY jest.config.ts ./
+COPY apps/web/package*.json ./apps/web/
+
+RUN npm install \
+  && npm install --prefix apps/web
+
+COPY . .
+
+RUN npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY package*.json ./
+
+RUN npm install --omit=dev
+
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/dist/web ./dist/web
+COPY --from=builder /app/static ./static
+
+EXPOSE 3000
+CMD ["node", "dist/main.js"]

--- a/apps/api/docker-compose.yml
+++ b/apps/api/docker-compose.yml
@@ -17,23 +17,53 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    profiles:
+      - dev
+      - ci
+      - test
 
   api:
     image: node:20
     working_dir: /workspace
-    command: sh -c "npm install && npm run prisma:generate && npm run prisma:migrate && npm run db:seed && npm run dev"
+    command: >
+      sh -c "npm install && npm install --prefix apps/web && npm run build && node dist/main.js"
     environment:
       NODE_ENV: development
-      DATABASE_URL: postgresql://busmedaus:busmedaus@postgres:5432/busmedaus_dev?schema=public
-      API_PORT: 3000
+      DB_HOST: postgres
+      DB_PORT: 5432
+      DB_USERNAME: busmedaus
+      DB_PASSWORD: busmedaus
+      DB_NAME: busmedaus_dev
     ports:
       - "3000:3000"
     volumes:
-      - ./apps/api:/workspace
+      - .:/workspace
     depends_on:
       postgres:
         condition: service_healthy
-    profiles: [dev]
+    profiles:
+      - dev
+
+  api-tests:
+    image: node:20
+    working_dir: /workspace
+    command: >
+      sh -c "npm install && npm install --prefix apps/web && npm test"
+    environment:
+      NODE_ENV: test
+      DB_HOST: postgres
+      DB_PORT: 5432
+      DB_USERNAME: busmedaus
+      DB_PASSWORD: busmedaus
+      DB_NAME: busmedaus_dev
+    volumes:
+      - .:/workspace
+    depends_on:
+      postgres:
+        condition: service_healthy
+    profiles:
+      - dev
+      - ci
 
 volumes:
   postgres-data:

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,18 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  rootDir: '.',
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/__tests__/**/*.spec.ts', '**/?(*.)+(spec|test).ts'],
+  transform: {
+    '^.+\\.(t|j)s$': ['ts-jest', { tsconfig: 'tsconfig.json' }]
+  },
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  testEnvironment: 'node',
+  clearMocks: true,
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/__tests__/**/*'],
+  coveragePathIgnorePatterns: ['/node_modules/', '/dist/'],
+  testPathIgnorePatterns: ['/node_modules/', '/dist/']
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:web": "npm --prefix apps/web run lint",
     "db:migrate": "ts-node src/database/run-migrations.ts",
     "db:seed": "ts-node src/database/seed.ts",
-    "test": "echo 'No automated tests yet'",
+    "test": "jest --runInBand",
     "test:web": "npm --prefix apps/web run test"
   },
   "dependencies": {
@@ -29,15 +29,21 @@
     "typeorm": "^0.3.17"
   },
   "devDependencies": {
+    "@nestjs/testing": "^10.0.0",
     "@types/bcryptjs": "^2.4.2",
+    "@types/express": "^4.17.21",
+    "@types/jest": "^29.5.12",
     "@types/jsonwebtoken": "^9.0.2",
     "@types/node": "^18.0.0",
-    "eslint": "^8.45.0",
-    "typescript": "^5.2.0",
-    "ts-node": "^10.9.1",
-    "ts-node-dev": "^2.0.0",
+    "@types/supertest": "^2.0.16",
     "@typescript-eslint/eslint-plugin": "^6.7.0",
     "@typescript-eslint/parser": "^6.7.0",
-    "@types/express": "^4.17.21"
+    "eslint": "^8.45.0",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4",
+    "ts-jest": "^29.1.1",
+    "ts-node": "^10.9.1",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.2.0"
   }
 }

--- a/src/users/__tests__/users.controller.e2e-spec.ts
+++ b/src/users/__tests__/users.controller.e2e-spec.ts
@@ -1,0 +1,137 @@
+import 'reflect-metadata';
+import { ExecutionContext, INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../../auth/guards/roles.guard';
+import { User } from '../user.entity';
+import { UsersRepository } from '../users.repository';
+import { UsersService } from '../users.service';
+import { UsersController } from '../users.controller';
+
+describe('UsersController (integration)', () => {
+  let app: INestApplication;
+  let repository: jest.Mocked<UsersRepository>;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [UsersController],
+      providers: [UsersService, UsersRepository]
+    })
+      .overrideProvider(UsersRepository)
+      .useValue({
+        findByEmail: jest.fn(),
+        create: jest.fn(),
+        save: jest.fn(),
+        findById: jest.fn(),
+        findAll: jest.fn()
+      })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({
+        canActivate: (context: ExecutionContext) => {
+          const req = context.switchToHttp().getRequest();
+          req.user = { userId: 'user-1', roles: ['admin'] };
+          return true;
+        }
+      })
+      .overrideGuard(RolesGuard)
+      .useValue({
+        canActivate: (context: ExecutionContext) => {
+          const req = context.switchToHttp().getRequest();
+          if (!req.user) {
+            req.user = { userId: 'user-1', roles: ['admin'] };
+          }
+          return true;
+        }
+      })
+      .compile();
+
+    repository = moduleRef.get(UsersRepository) as jest.Mocked<UsersRepository>;
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('returns a sanitised list of users for administrators', async () => {
+    const now = new Date();
+    const users: User[] = [
+      {
+        id: 'user-1',
+        email: 'admin@example.com',
+        firstName: 'Admin',
+        lastName: 'User',
+        phoneNumber: null,
+        passwordHash: 'hash',
+        roles: ['admin'],
+        isActive: true,
+        createdAt: now,
+        updatedAt: now
+      } as unknown as User
+    ];
+
+    repository.findAll.mockResolvedValue(users);
+
+    const response = await request(app.getHttpServer()).get('/users').expect(200);
+
+    expect(repository.findAll).toHaveBeenCalledTimes(1);
+    expect(response.body).toEqual([
+      expect.objectContaining({
+        id: 'user-1',
+        email: 'admin@example.com',
+        firstName: 'Admin',
+        lastName: 'User',
+        phoneNumber: null,
+        roles: ['admin'],
+        isActive: true
+      })
+    ]);
+    expect(new Date(response.body[0].createdAt).toISOString()).toBe(now.toISOString());
+    expect(new Date(response.body[0].updatedAt).toISOString()).toBe(now.toISOString());
+    expect(response.body[0]).not.toHaveProperty('passwordHash');
+  });
+
+  it('returns the current user profile via the /users/me endpoint', async () => {
+    const now = new Date();
+    const me = {
+      id: 'user-1',
+      email: 'admin@example.com',
+      firstName: 'Admin',
+      lastName: 'User',
+      phoneNumber: '123456789',
+      passwordHash: 'hash',
+      roles: ['admin'],
+      isActive: true,
+      createdAt: now,
+      updatedAt: now
+    } as unknown as User;
+
+    repository.findById.mockResolvedValue(me);
+
+    const response = await request(app.getHttpServer())
+      .get('/users/me')
+      .set('Authorization', 'Bearer test-token')
+      .expect(200);
+
+    expect(repository.findById).toHaveBeenCalledWith('user-1', undefined);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        id: 'user-1',
+        email: 'admin@example.com',
+        firstName: 'Admin',
+        lastName: 'User',
+        phoneNumber: '123456789',
+        roles: ['admin'],
+        isActive: true
+      })
+    );
+    expect(response.body).not.toHaveProperty('passwordHash');
+  });
+});

--- a/src/users/__tests__/users.service.spec.ts
+++ b/src/users/__tests__/users.service.spec.ts
@@ -1,0 +1,155 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as bcrypt from 'bcryptjs';
+import { CreateUserDto } from '../dto/create-user.dto';
+import { UpdateUserDto } from '../dto/update-user.dto';
+import { User } from '../user.entity';
+import { UsersRepository } from '../users.repository';
+import { UsersService } from '../users.service';
+
+describe('UsersService', () => {
+  let service: UsersService;
+  let repository: jest.Mocked<UsersRepository>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UsersService,
+        {
+          provide: UsersRepository,
+          useValue: {
+            findByEmail: jest.fn(),
+            create: jest.fn(),
+            save: jest.fn(),
+            findById: jest.fn(),
+            findAll: jest.fn()
+          }
+        }
+      ]
+    }).compile();
+
+    service = module.get(UsersService);
+    repository = module.get(UsersRepository) as jest.Mocked<UsersRepository>;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('createUser', () => {
+    it('hashes the password, normalises the payload, and persists the user', async () => {
+      const dto: CreateUserDto = {
+        email: 'TestUser@Example.COM',
+        firstName: '  Jane ',
+        lastName: ' Doe  ',
+        phoneNumber: ' 123456789 ',
+        password: 'Sup3rSecret!',
+        roles: ['admin']
+      };
+
+      const createdUser = {
+        id: 'user-1',
+        email: 'testuser@example.com',
+        firstName: 'Jane',
+        lastName: 'Doe',
+        phoneNumber: '123456789',
+        passwordHash: 'hashed-password',
+        roles: ['admin'],
+        isActive: true
+      } as unknown as User;
+
+      jest.spyOn(bcrypt, 'hash').mockResolvedValue('hashed-password');
+      repository.findByEmail.mockResolvedValue(null);
+      repository.create.mockReturnValue(createdUser);
+      repository.save.mockResolvedValue(createdUser);
+
+      const result = await service.createUser(dto);
+
+      expect(repository.findByEmail).toHaveBeenCalledWith('testuser@example.com', undefined);
+      expect(bcrypt.hash).toHaveBeenCalledWith('Sup3rSecret!', 12);
+      expect(repository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: 'testuser@example.com',
+          firstName: 'Jane',
+          lastName: 'Doe',
+          phoneNumber: '123456789',
+          passwordHash: 'hashed-password',
+          roles: ['admin'],
+          isActive: true
+        }),
+        undefined
+      );
+      expect(repository.save).toHaveBeenCalledWith(createdUser, undefined);
+      expect(result).toBe(createdUser);
+    });
+
+    it('throws when a user with the e-mail already exists', async () => {
+      repository.findByEmail.mockResolvedValue({} as User);
+
+      await expect(
+        service.createUser({
+          email: 'existing@example.com',
+          password: 'Password123',
+          firstName: 'Existing',
+          lastName: 'User'
+        })
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('findByIdOrFail', () => {
+    it('throws a NotFoundException when the user is missing', async () => {
+      repository.findById.mockResolvedValue(null);
+
+      await expect(service.findByIdOrFail('missing-user')).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('updateUser', () => {
+    it('applies updates and persists the entity', async () => {
+      const existingUser = {
+        id: 'user-2',
+        email: 'member@example.com',
+        firstName: 'Old',
+        lastName: 'Name',
+        phoneNumber: '555-1234',
+        passwordHash: 'hash',
+        roles: ['member'],
+        isActive: true
+      } as unknown as User;
+
+      repository.findById.mockResolvedValue(existingUser);
+      repository.save.mockImplementation(async (user: User) => user);
+
+      const dto: UpdateUserDto = {
+        firstName: '  New  ',
+        lastName: '  Person ',
+        phoneNumber: ' 987-6543 ',
+        roles: ['manager'],
+        isActive: false
+      };
+
+      const result = await service.updateUser(existingUser.id, dto);
+
+      expect(existingUser.firstName).toBe('New');
+      expect(existingUser.lastName).toBe('Person');
+      expect(existingUser.phoneNumber).toBe('987-6543');
+      expect(existingUser.roles).toEqual(['manager']);
+      expect(existingUser.isActive).toBe(false);
+      expect(repository.save).toHaveBeenCalledWith(existingUser, undefined);
+      expect(result).toBe(existingUser);
+    });
+
+    it('rejects empty role updates', async () => {
+      repository.findById.mockResolvedValue({
+        id: 'user-3'
+      } as User);
+
+      await expect(
+        service.updateUser('user-3', {
+          roles: []
+        })
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,11 @@
     "skipLibCheck": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/__tests__/**/*",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
 }


### PR DESCRIPTION
## Summary
- add a Jest configuration with unit and integration suites under `src/**/__tests__`
- provision a multi-stage Dockerfile and compose profiles for the NestJS service and test runner
- wire up a GitHub Actions workflow that lints, tests, builds, and publishes container images on main

## Testing
- `npm install --no-progress` *(fails: 403 Forbidden from registry.npmjs.org via proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d04d14f3988333891e2fccc3057943