### PR TITLE
Add test for Firebase private key sanitization

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,6 @@ Email and push notifications are now sent through SendGrid and Firebase Cloud Me
 | `SENDGRID_FROM_EMAIL` | Verified sender used for outbound messages. |
 | `FIREBASE_PROJECT_ID` | Firebase project identifier for FCM. |
 | `FIREBASE_CLIENT_EMAIL` | Service account client email for FCM. |
-| `FIREBASE_PRIVATE_KEY` | Service account private key (use `\n` for newlines). |
+| `FIREBASE_PRIVATE_KEY` | Service account private key (literal `\n` escapes are converted to newlines). |
 
 Client devices register push tokens by calling `POST /notifications/subscriptions`, and tokens can be revoked with `DELETE /notifications/subscriptions/:id`. Each domain module now passes channel hints so that the `NotificationsService` fans out in-app, email, and push payloads while recording delivery status metadata on the notification records.

--- a/src/notifications/notifications.module.spec.ts
+++ b/src/notifications/notifications.module.spec.ts
@@ -1,0 +1,69 @@
+import 'reflect-metadata';
+import { MODULE_METADATA } from '@nestjs/common/constants';
+import { FIREBASE_MESSAGING } from './notifications.constants';
+
+jest.mock('firebase-admin/app', () => ({
+  __esModule: true,
+  cert: jest.fn(),
+  getApps: jest.fn(),
+  initializeApp: jest.fn()
+}));
+
+jest.mock('firebase-admin/messaging', () => ({
+  __esModule: true,
+  getMessaging: jest.fn()
+}));
+
+describe('firebase messaging provider', () => {
+  const originalEnv = process.env;
+  let mockApp: jest.Mocked<typeof import('firebase-admin/app')>;
+  let mockMessaging: jest.Mocked<typeof import('firebase-admin/messaging')>;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    mockApp = jest.requireMock('firebase-admin/app') as jest.Mocked<
+      typeof import('firebase-admin/app')
+    >;
+    mockMessaging = jest.requireMock('firebase-admin/messaging') as jest.Mocked<
+      typeof import('firebase-admin/messaging')
+    >;
+    jest.clearAllMocks();
+
+    mockApp.cert.mockReturnValue('mock-cert');
+    mockApp.getApps.mockReturnValue([]);
+    mockApp.initializeApp.mockImplementation((_config, name: string) => ({ name }));
+    mockMessaging.getMessaging.mockReturnValue('mock-messaging');
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('sanitizes newline escapes before Firebase initialization', async () => {
+    process.env.FIREBASE_PROJECT_ID = 'project-id';
+    process.env.FIREBASE_CLIENT_EMAIL = 'client@example.com';
+    process.env.FIREBASE_PRIVATE_KEY = 'line-one\\nline-two';
+
+    const { NotificationsModule } = await import('./notifications.module');
+    const providers = Reflect.getMetadata(
+      MODULE_METADATA.PROVIDERS,
+      NotificationsModule
+    ) as Array<{ provide: unknown; useFactory: () => unknown }>;
+
+    const firebaseMessagingProvider = providers.find(
+      (provider) => provider.provide === FIREBASE_MESSAGING
+    );
+
+    expect(firebaseMessagingProvider).toBeDefined();
+
+    const messaging = firebaseMessagingProvider!.useFactory();
+
+    expect(messaging).toBe('mock-messaging');
+    expect(mockApp.cert).toHaveBeenCalledTimes(1);
+
+    const [credentials] = mockApp.cert.mock.calls[0] as [{ privateKey: string }];
+    expect(credentials.privateKey).toContain('\n');
+    expect(credentials.privateKey).not.toContain('\\n');
+  });
+});

--- a/src/notifications/notifications.module.ts
+++ b/src/notifications/notifications.module.ts
@@ -45,6 +45,7 @@ const firebaseMessagingProvider = {
     }
 
     try {
+      // Convert escaped newlines into actual line breaks for Firebase credentials.
       const sanitizedPrivateKey = privateKey.replace(/\\n/g, '\n');
       const existing = getApps().find((app) => app.name === 'busmedaus-notifications');
       const app =


### PR DESCRIPTION
## Summary
- document the newline conversion in the Firebase messaging provider
- add a unit test that exercises the notifications module factory with a key containing `\n` escapes
- clarify the README to note that literal `\n` sequences are supported for the Firebase private key

## Testing
- npm test *(fails: local Jest binary is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d055f3f7408333935b4bb9b75047b9