### PR TITLE
Ensure Firebase private key newline sanitization and typing

### DIFF
--- a/src/notifications/notifications.module.spec.ts
+++ b/src/notifications/notifications.module.spec.ts
@@ -1,5 +1,7 @@
 import 'reflect-metadata';
 import { MODULE_METADATA } from '@nestjs/common/constants';
+import type { App, Credential } from 'firebase-admin/app';
+import type { Messaging } from 'firebase-admin/messaging';
 import { FIREBASE_MESSAGING } from './notifications.constants';
 
 jest.mock('firebase-admin/app', () => ({
@@ -30,10 +32,12 @@ describe('firebase messaging provider', () => {
     >;
     jest.clearAllMocks();
 
-    mockApp.cert.mockReturnValue('mock-cert');
+    mockApp.cert.mockReturnValue('mock-cert' as unknown as Credential);
     mockApp.getApps.mockReturnValue([]);
-    mockApp.initializeApp.mockImplementation((_config, name: string) => ({ name }));
-    mockMessaging.getMessaging.mockReturnValue('mock-messaging');
+    mockApp.initializeApp.mockImplementation(
+      (_config, name?: string) => ({ name } as unknown as App)
+    );
+    mockMessaging.getMessaging.mockReturnValue('mock-messaging' as unknown as Messaging);
   });
 
   afterEach(() => {

--- a/src/notifications/notifications.module.ts
+++ b/src/notifications/notifications.module.ts
@@ -45,7 +45,7 @@ const firebaseMessagingProvider = {
     }
 
     try {
-      // Convert escaped newlines into actual line breaks for Firebase credentials.
+      // Convert escaped '\n' sequences into actual line breaks for Firebase credentials.
       const sanitizedPrivateKey = privateKey.replace(/\\n/g, '\n');
       const existing = getApps().find((app) => app.name === 'busmedaus-notifications');
       const app =


### PR DESCRIPTION
## Summary
- document that the Firebase private key sanitizer converts escaped `\n` sequences into real newlines before initialization
- update the notifications module spec to use Firebase types when mocking so ts-jest accepts the return values while validating newline handling

## Testing
- npm test *(fails: existing TypeScript errors in unrelated specs and services)*

------
https://chatgpt.com/codex/tasks/task_e_68d0648a7e2c83339cdfc8c06ffe37fd