### PR TITLE
Add postinstall hook and streamline dependency installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,8 @@ jobs:
           node-version: 20
           cache: npm
 
-      - name: Install backend dependencies
+      - name: Install dependencies
         run: npm install
-
-      - name: Install web dependencies
-        run: npm install
-        working-directory: apps/web
 
       - name: Lint
         run: npm run lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@ COPY .eslintrc.json ./
 COPY jest.config.ts ./
 COPY apps/web/package*.json ./apps/web/
 
-RUN npm install \
-  && npm install --prefix apps/web
+RUN npm install
 
 COPY . .
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ npm run db:seed # optional
 node dist/main.js
 ```
 
+The root `npm install` command runs a `postinstall` hook that installs the React console dependencies under `apps/web`, ensuring
+`npm run build` has everything it needs to produce both the backend and front-end bundles.
+
 The backend requires access to PostgreSQL. Connection details are read from the `DB_*` environment variables in `src/app.module.ts`.
 By default the service expects a database named `busmedaus` available on `localhost:5432` with the `postgres` user. Adjust the
 variables above to match your environment before running the migrations or starting the API. Once running, the server listens on

--- a/apps/api/docker-compose.yml
+++ b/apps/api/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     image: node:20
     working_dir: /workspace
     command: >
-      sh -c "npm install && npm install --prefix apps/web && npm run build && node dist/main.js"
+      sh -c "npm install && npm run build && node dist/main.js"
     environment:
       NODE_ENV: development
       DB_HOST: postgres
@@ -48,7 +48,7 @@ services:
     image: node:20
     working_dir: /workspace
     command: >
-      sh -c "npm install && npm install --prefix apps/web && npm test"
+      sh -c "npm install && npm test"
     environment:
       NODE_ENV: test
       DB_HOST: postgres

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -2,7 +2,6 @@ import js from "@eslint/js";
 import globals from "globals";
 import pluginReact from "eslint-plugin-react";
 import pluginReactHooks from "eslint-plugin-react-hooks";
-import pluginReactRefresh from "eslint-plugin-react-refresh";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
@@ -20,21 +19,14 @@ export default tseslint.config(
     },
     plugins: {
       react: pluginReact,
-      "react-hooks": pluginReactHooks,
-      "react-refresh": pluginReactRefresh
+      "react-hooks": pluginReactHooks
     },
     rules: {
       ...pluginReact.configs.flat.recommended.rules,
       "react/jsx-uses-react": "off",
       "react/react-in-jsx-scope": "off",
       "react-hooks/rules-of-hooks": "error",
-      "react-hooks/exhaustive-deps": "warn",
-      "react-refresh/only-export-components": [
-        "warn",
-        {
-          allowConstantExport: true
-        }
-      ]
+      "react-hooks/exhaustive-deps": "warn"
     }
   }
 );

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,7 +32,6 @@
     "eslint": "^9.5.0",
     "eslint-plugin-react": "^7.34.3",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-react-refresh": "^0.4.6",
     "globals": "^15.6.0",
     "postcss": "^8.4.38",
     "prettier": "^3.3.2",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "npm run build:web && tsc -p tsconfig.json",
     "build:web": "npm --prefix apps/web run build",
+    "postinstall": "npm install --prefix apps/web --legacy-peer-deps",
     "dev:web": "npm --prefix apps/web run dev",
     "lint": "eslint .",
     "lint:web": "npm --prefix apps/web run lint",


### PR DESCRIPTION
## Summary
- add a root `postinstall` script that installs the web app dependencies (using `--legacy-peer-deps`) so a single `npm install` prepares both bundles and document the behaviour in the README
- rely on the new hook from the Docker builder stage, docker-compose profiles, and CI workflow to eliminate redundant `apps/web` install steps
- simplify the web ESLint configuration by dropping the React Refresh plugin that conflicted with the repository's ESLint version

## Testing
- npm install && npm run build *(fails in the evaluation environment: npm 403 Forbidden while downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d2406f851083338d1bb41e73830224