### PR TITLE
feat: surface hive telemetry data

### DIFF
--- a/apps/web/src/features/hives/HivesPage.test.tsx
+++ b/apps/web/src/features/hives/HivesPage.test.tsx
@@ -1,0 +1,99 @@
+import type { ReactElement } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import HivesPage from "./HivesPage";
+import { apiClient } from "../../lib/apiClient";
+import type { Hive } from "../../types";
+
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false
+      }
+    }
+  });
+
+let testQueryClient: QueryClient | null = null;
+
+const renderWithClient = (ui: ReactElement) => {
+  const client = createTestQueryClient();
+  testQueryClient = client;
+
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+};
+
+describe("HivesPage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    testQueryClient?.clear();
+    testQueryClient = null;
+  });
+
+  it("renders hive telemetry from the API client", async () => {
+    const hives: Hive[] = [
+      {
+        id: "hive-1",
+        name: "Ąžuolas",
+        description: null,
+        owner: { id: "user-1", email: "owner@example.com", roles: ["keeper"] },
+        members: [],
+        createdAt: new Date("2025-01-10T09:00:00.000Z").toISOString(),
+        updatedAt: new Date("2025-01-12T09:00:00.000Z").toISOString(),
+        telemetry: {
+          location: "Vilniaus raj.",
+          queenStatus: "aktyvi",
+          productivityIndex: 87.3,
+          lastInspectionAt: "2025-01-11T08:30:00.000Z",
+          temperature: 34.2,
+          humidity: 57.2
+        }
+      }
+    ];
+
+    const spy = vi.spyOn(apiClient, "get").mockResolvedValue(hives);
+
+    renderWithClient(<HivesPage />);
+
+    await waitFor(() => expect(screen.getByText(/Ąžuolas/)).toBeInTheDocument());
+    expect(screen.getByText(/Vilniaus raj\./)).toBeInTheDocument();
+    expect(screen.getByText(/87.3/)).toBeInTheDocument();
+    expect(screen.getByText(/34.2°C/)).toBeInTheDocument();
+    expect(screen.getByText(/57%/)).toBeInTheDocument();
+    expect(screen.getByText(/aktyvi/i)).toBeInTheDocument();
+    expect(spy).toHaveBeenCalledWith("/hives");
+  });
+
+  it("displays fallbacks when telemetry data is unavailable", async () => {
+    const hives: Hive[] = [
+      {
+        id: "hive-2",
+        name: "Liepa",
+        description: null,
+        owner: { id: "user-2", email: "keeper@example.com", roles: ["keeper"] },
+        members: [],
+        createdAt: new Date("2025-01-05T09:00:00.000Z").toISOString(),
+        updatedAt: new Date("2025-01-05T09:00:00.000Z").toISOString(),
+        telemetry: {
+          location: null,
+          queenStatus: null,
+          productivityIndex: null,
+          lastInspectionAt: null,
+          temperature: null,
+          humidity: null
+        }
+      }
+    ];
+
+    vi.spyOn(apiClient, "get").mockResolvedValue(hives);
+
+    renderWithClient(<HivesPage />);
+
+    await waitFor(() => expect(screen.getByText(/Liepa/)).toBeInTheDocument());
+    expect(screen.getByText(/Vieta nenustatyta/)).toBeInTheDocument();
+    expect(screen.getAllByText(/Nėra duomenų/)).toHaveLength(3);
+    expect(screen.getByText(/Nežinomas statusas/)).toBeInTheDocument();
+    expect(screen.getByText(/Paskutinė apžiūra nenurodyta/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -1,12 +1,27 @@
+export type HiveTelemetry = {
+  location?: string | null;
+  queenStatus?: string | null;
+  productivityIndex?: number | null;
+  lastInspectionAt?: string | null;
+  temperature?: number | null;
+  humidity?: number | null;
+};
+
+export type HiveUserSummary = {
+  id: string;
+  email: string;
+  roles: string[];
+};
+
 export type Hive = {
   id: string;
   name: string;
-  queenStatus: "aktyvi" | "per žiemą" | "keisti";
-  productivityIndex: number;
-  lastInspection: string;
-  location: string;
-  temperature: number;
-  humidity: number;
+  description?: string | null;
+  owner: HiveUserSummary;
+  members: HiveUserSummary[];
+  createdAt: string;
+  updatedAt: string;
+  telemetry: HiveTelemetry;
 };
 
 export type Task = {

--- a/src/database/data-source.ts
+++ b/src/database/data-source.ts
@@ -10,6 +10,7 @@ import { RefreshToken } from '../auth/refresh-token.entity';
 import { CreateCoreTables1699999999999 } from '../migrations/1699999999999-create-core-tables';
 import { AlignTypeormSchema1700000000000 } from '../migrations/1700000000000-align-typeorm-schema';
 import { NotificationTransports1700000000100 } from '../migrations/1700000000100-notification-transports';
+import { AddHiveTelemetry1700000000201 } from '../migrations/1700000000201-add-hive-telemetry';
 
 const getBoolean = (value: string | undefined, fallback = false): boolean => {
   if (value === undefined) {
@@ -27,7 +28,12 @@ export const AppDataSource = new DataSource({
   database: process.env.DB_NAME || 'busmedaus',
   ssl: getBoolean(process.env.DB_SSL) ? { rejectUnauthorized: process.env.DB_SSL_REJECT_UNAUTHORIZED !== 'false' } : false,
   entities: [User, Hive, Task, Notification, NotificationSubscription, MediaItem, Comment, RefreshToken],
-  migrations: [CreateCoreTables1699999999999, AlignTypeormSchema1700000000000, NotificationTransports1700000000100],
+  migrations: [
+    CreateCoreTables1699999999999,
+    AlignTypeormSchema1700000000000,
+    NotificationTransports1700000000100,
+    AddHiveTelemetry1700000000201
+  ],
   migrationsTableName: 'typeorm_migrations',
   synchronize: false
 });

--- a/src/hives/hive.entity.ts
+++ b/src/hives/hive.entity.ts
@@ -43,6 +43,27 @@ export class Hive {
   @Column({ nullable: true })
   queenStatus?: string;
 
+  @Column({
+    type: 'numeric',
+    precision: 10,
+    scale: 2,
+    nullable: true,
+    transformer: {
+      to: (value?: number | null) => value,
+      from: (value: string | null) => (value === null ? null : Number(value))
+    }
+  })
+  productivityIndex?: number | null;
+
+  @Column({ type: 'timestamp', nullable: true })
+  lastInspectionAt?: Date | null;
+
+  @Column({ type: 'double precision', nullable: true })
+  temperature?: number | null;
+
+  @Column({ type: 'double precision', nullable: true })
+  humidity?: number | null;
+
   @Column({ nullable: true })
   temperament?: string;
 

--- a/src/hives/hives.controller.ts
+++ b/src/hives/hives.controller.ts
@@ -14,6 +14,15 @@ interface HiveUserSummary {
   roles: string[];
 }
 
+interface HiveTelemetry {
+  location: string | null;
+  queenStatus: string | null;
+  productivityIndex: number | null;
+  lastInspectionAt: string | null;
+  temperature: number | null;
+  humidity: number | null;
+}
+
 interface HiveResponse {
   id: string;
   name: string;
@@ -22,6 +31,7 @@ interface HiveResponse {
   members: HiveUserSummary[];
   createdAt: Date;
   updatedAt: Date;
+  telemetry: HiveTelemetry;
 }
 
 function mapUser(user: { id: string; email: string; roles: string[] }): HiveUserSummary {
@@ -36,7 +46,15 @@ function mapHive(hive: Hive): HiveResponse {
     owner: mapUser(hive.owner),
     members: hive.members.map(mapUser),
     createdAt: hive.createdAt,
-    updatedAt: hive.updatedAt
+    updatedAt: hive.updatedAt,
+    telemetry: {
+      location: hive.location ?? null,
+      queenStatus: hive.queenStatus ?? null,
+      productivityIndex: hive.productivityIndex ?? null,
+      lastInspectionAt: hive.lastInspectionAt ? hive.lastInspectionAt.toISOString() : null,
+      temperature: hive.temperature ?? null,
+      humidity: hive.humidity ?? null
+    }
   };
 }
 

--- a/src/migrations/1700000000201-add-hive-telemetry.ts
+++ b/src/migrations/1700000000201-add-hive-telemetry.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddHiveTelemetry1700000000201 implements MigrationInterface {
+  name = 'AddHiveTelemetry1700000000201';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "hives" ADD COLUMN IF NOT EXISTS "productivityIndex" numeric(10,2)`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "hives" ADD COLUMN IF NOT EXISTS "lastInspectionAt" TIMESTAMP`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "hives" ADD COLUMN IF NOT EXISTS "temperature" double precision`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "hives" ADD COLUMN IF NOT EXISTS "humidity" double precision`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "hives" DROP COLUMN IF EXISTS "humidity"`);
+    await queryRunner.query(`ALTER TABLE "hives" DROP COLUMN IF EXISTS "temperature"`);
+    await queryRunner.query(`ALTER TABLE "hives" DROP COLUMN IF EXISTS "lastInspectionAt"`);
+    await queryRunner.query(`ALTER TABLE "hives" DROP COLUMN IF EXISTS "productivityIndex"`);
+  }
+}


### PR DESCRIPTION
## Summary
- add telemetry fields to the Hive entity, controller projection, and database migrations
- include the new migration in the data source so telemetry is persisted
- update the web hive list to consume the telemetry payload safely and cover the view with tests

## Testing
- `npm test` *(fails: existing TypeScript errors in notifications service and bcrypt mocks)*
- `npm --prefix apps/web run test` *(blocked: npm registry denied access to @heroicons/react so vitest is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68d24937351c8333b6bacb753695e3b4