### PR TITLE
Add dashboard endpoint, task/media/message APIs, and web mappings

### DIFF
--- a/apps/web/src/features/dashboard/DashboardPage.test.tsx
+++ b/apps/web/src/features/dashboard/DashboardPage.test.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import DashboardPage, { type DashboardSnapshot } from "./DashboardPage";
+import DashboardPage, { type DashboardApiSnapshot } from "./DashboardPage";
 import { apiClient } from "../../lib/apiClient";
 
 const createTestQueryClient = () =>
@@ -31,14 +31,14 @@ describe("DashboardPage", () => {
   });
 
   it("renders metrics, tasks and alerts from the API client", async () => {
-    const snapshot: DashboardSnapshot = {
+    const payload: DashboardApiSnapshot = {
       stats: [
         {
           id: "hive-health",
           label: "Sveikų avilių",
           value: "92%",
           trend: "+4.1% nuo praėjusios savaitės",
-          trendTone: "positive"
+          trendTone: "info"
         }
       ],
       alerts: [
@@ -62,7 +62,7 @@ describe("DashboardPage", () => {
       ]
     };
 
-    const spy = vi.spyOn(apiClient, "get").mockResolvedValue(snapshot);
+    const spy = vi.spyOn(apiClient, "get").mockResolvedValue(payload);
 
     renderWithClient(<DashboardPage />);
 

--- a/apps/web/src/features/media/MediaPage.test.tsx
+++ b/apps/web/src/features/media/MediaPage.test.tsx
@@ -1,0 +1,66 @@
+import type { ReactElement } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import MediaPage from "./MediaPage";
+import { apiClient } from "../../lib/apiClient";
+
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false
+      }
+    }
+  });
+
+let testQueryClient: QueryClient | null = null;
+
+const renderWithClient = (ui: ReactElement) => {
+  const client = createTestQueryClient();
+  testQueryClient = client;
+
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+};
+
+describe("MediaPage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    testQueryClient?.clear();
+    testQueryClient = null;
+  });
+
+  it("formats media cards with localized metadata", async () => {
+    const payload = [
+      {
+        id: "media-1",
+        url: "https://example.com/photo.jpg",
+        mimeType: "image/jpeg",
+        description: "Nuotrauka",
+        metadata: { tags: ["profilaktika"] },
+        capturedAt: "2025-04-20T00:00:00.000Z",
+        hive: { id: "hive-1", name: "A1" },
+        uploader: {
+          id: "user-1",
+          email: "asta@example.com",
+          roles: ["keeper"],
+          firstName: "Asta",
+          lastName: "Bitė",
+          displayName: ""
+        },
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      }
+    ];
+
+    const spy = vi.spyOn(apiClient, "get").mockResolvedValue(payload);
+
+    renderWithClient(<MediaPage />);
+
+    await waitFor(() => expect(screen.getByText(/Avilys hive-1/i)).toBeInTheDocument());
+    expect(screen.getByText(/Asta Bitė/)).toBeInTheDocument();
+    expect(screen.getByText(/profilaktika/)).toBeInTheDocument();
+    expect(screen.getByText(/2025-04-20/)).toBeInTheDocument();
+    expect(spy).toHaveBeenCalledWith("/media");
+  });
+});

--- a/apps/web/src/features/messaging/MessagingPage.test.tsx
+++ b/apps/web/src/features/messaging/MessagingPage.test.tsx
@@ -1,0 +1,62 @@
+import type { ReactElement } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import MessagingPage from "./MessagingPage";
+import { apiClient } from "../../lib/apiClient";
+
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false
+      }
+    }
+  });
+
+let testQueryClient: QueryClient | null = null;
+
+const renderWithClient = (ui: ReactElement) => {
+  const client = createTestQueryClient();
+  testQueryClient = client;
+
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+};
+
+describe("MessagingPage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    testQueryClient?.clear();
+    testQueryClient = null;
+  });
+
+  it("shows localized messaging entries", async () => {
+    const payload = [
+      {
+        id: "msg-1",
+        task: { id: "task-1", title: "Ventiliacija", hiveId: "hive-1", hiveName: "A1" },
+        author: {
+          id: "user-2",
+          email: "ieva@example.com",
+          roles: ["keeper"],
+          firstName: "Ieva",
+          lastName: "Medune",
+          displayName: ""
+        },
+        content: "Patikrinkite ventiliaciją asap",
+        createdAt: new Date().toISOString(),
+        isOwn: false
+      }
+    ];
+
+    const spy = vi.spyOn(apiClient, "get").mockResolvedValue(payload);
+
+    renderWithClient(<MessagingPage />);
+
+    await waitFor(() => expect(screen.getByText("Ieva Medune")).toBeInTheDocument());
+    expect(screen.getByText(/Patikrinkite ventiliaciją asap/)).toBeInTheDocument();
+    expect(screen.getByText(/Programėlė/)).toBeInTheDocument();
+    expect(screen.getByText(/nauja/i)).toBeInTheDocument();
+    expect(spy).toHaveBeenCalledWith("/messages");
+  });
+});

--- a/apps/web/src/features/tasks/TasksPage.test.tsx
+++ b/apps/web/src/features/tasks/TasksPage.test.tsx
@@ -1,0 +1,68 @@
+import type { ReactElement } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import TasksPage from "./TasksPage";
+import { apiClient } from "../../lib/apiClient";
+
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false
+      }
+    }
+  });
+
+let testQueryClient: QueryClient | null = null;
+
+const renderWithClient = (ui: ReactElement) => {
+  const client = createTestQueryClient();
+  testQueryClient = client;
+
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+};
+
+describe("TasksPage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    testQueryClient?.clear();
+    testQueryClient = null;
+  });
+
+  it("maps API data into Lithuanian labels", async () => {
+    const payload = [
+      {
+        id: "task-1",
+        title: "Patikra",
+        dueDate: "2025-09-22T00:00:00.000Z",
+        status: "IN_PROGRESS",
+        statusLabel: "Vykdoma",
+        priority: 2,
+        priorityLabel: "Vidutinė",
+        hive: { id: "hive-1", name: "A1" },
+        assignedTo: {
+          id: "user-1",
+          email: "rokas@example.com",
+          roles: ["keeper"],
+          firstName: "Rokas",
+          lastName: "Bitė",
+          displayName: "Rokas"
+        },
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      }
+    ];
+
+    const spy = vi.spyOn(apiClient, "get").mockResolvedValue(payload);
+
+    renderWithClient(<TasksPage />);
+
+    await waitFor(() => expect(screen.getByText("Patikra")).toBeInTheDocument());
+    expect(screen.getByText("Rokas")).toBeInTheDocument();
+    expect(screen.getByText("2025-09-22")).toBeInTheDocument();
+    expect(screen.getByText("VIDUTINĖ")).toBeInTheDocument();
+    expect(screen.getByText("VYKDOMA")).toBeInTheDocument();
+    expect(spy).toHaveBeenCalledWith("/tasks");
+  });
+});

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -14,7 +14,7 @@ export type Task = {
   title: string;
   assignedTo: string;
   dueDate: string;
-  status: "laukiama" | "vykdoma" | "užbaigta" | "kritinė";
+  status: "laukiama" | "vykdoma" | "užbaigta" | "kritinė" | "atšaukta";
   priority: "žema" | "vidutinė" | "aukšta";
 };
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { AuditModule } from './audit/audit.module';
 import { AuthModule } from './auth/auth.module';
 import { MessagingModule } from './messaging/messaging.module';
 import { MediaModule } from './media/media.module';
+import { DashboardModule } from './dashboard/dashboard.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { TasksModule } from './tasks/tasks.module';
 import { HivesModule } from './hives/hives.module';
@@ -36,7 +37,8 @@ import { UsersModule } from './users/users.module';
     TasksModule,
     NotificationsModule,
     MessagingModule,
-    MediaModule
+    MediaModule,
+    DashboardModule
   ]
 })
 export class AppModule implements NestModule {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -144,9 +144,11 @@ export class AuthService {
       roles: user.roles,
       type: 'access'
     };
-    const accessToken = jwt.sign(accessPayload, this.jwtSecret, {
-      expiresIn: this.accessTokenExpiry
-    });
+    const accessToken = jwt.sign(
+      accessPayload,
+      this.jwtSecret as jwt.Secret,
+      { expiresIn: this.accessTokenExpiry } as jwt.SignOptions
+    ) as string;
 
     const tokenId = randomUUID();
     const refreshPayload: JwtPayload = {
@@ -157,9 +159,11 @@ export class AuthService {
       tokenId
     };
 
-    const refreshToken = jwt.sign(refreshPayload, this.jwtSecret, {
-      expiresIn: Math.floor(this.refreshTokenTtlMs / 1000)
-    });
+    const refreshToken = jwt.sign(
+      refreshPayload,
+      this.jwtSecret as jwt.Secret,
+      { expiresIn: Math.floor(this.refreshTokenTtlMs / 1000) } as jwt.SignOptions
+    ) as string;
 
     const refreshExpiresAt = new Date(Date.now() + this.refreshTokenTtlMs);
     const tokenHash = await bcrypt.hash(refreshToken, 12);

--- a/src/dashboard/dashboard.controller.ts
+++ b/src/dashboard/dashboard.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { AuthenticatedUser, CurrentUser } from '../auth/decorators/current-user.decorator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { DashboardService } from './dashboard.service';
+import type { DashboardSnapshot } from './types';
+
+@Controller('dashboard')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class DashboardController {
+  constructor(private readonly dashboardService: DashboardService) {}
+
+  @Get()
+  getSnapshot(@CurrentUser() user: AuthenticatedUser): Promise<DashboardSnapshot> {
+    return this.dashboardService.getSnapshot(user);
+  }
+}

--- a/src/dashboard/dashboard.module.ts
+++ b/src/dashboard/dashboard.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { HivesModule } from '../hives/hives.module';
+import { MediaModule } from '../media/media.module';
+import { MessagingModule } from '../messaging/messaging.module';
+import { NotificationsModule } from '../notifications/notifications.module';
+import { TasksModule } from '../tasks/tasks.module';
+import { DashboardController } from './dashboard.controller';
+import { DashboardService } from './dashboard.service';
+
+@Module({
+  imports: [HivesModule, TasksModule, NotificationsModule, MediaModule, MessagingModule],
+  controllers: [DashboardController],
+  providers: [DashboardService]
+})
+export class DashboardModule {}

--- a/src/dashboard/dashboard.service.ts
+++ b/src/dashboard/dashboard.service.ts
@@ -1,0 +1,167 @@
+import { Injectable } from '@nestjs/common';
+import { AuthenticatedUser } from '../auth/decorators/current-user.decorator';
+import { HivesRepository } from '../hives/hives.repository';
+import { NotificationsService } from '../notifications/notifications.service';
+import { NotificationStatus } from '../notifications/notification.entity';
+import { MediaService } from '../media/media.service';
+import { MessagingService } from '../messaging/messaging.service';
+import { TasksService } from '../tasks/tasks.service';
+import { TaskStatus } from '../tasks/task-status.enum';
+import { formatTaskPriorityLabel, formatTaskStatusLabel, formatUserDisplayName } from '../tasks/task.presenter';
+import type { DashboardSnapshot, DashboardStat, DashboardTask, DashboardAlert } from './types';
+
+const formatNumber = (value: number): string =>
+  new Intl.NumberFormat('lt-LT', { maximumFractionDigits: 0 }).format(value);
+
+const formatDate = (value: Date | null | undefined): string => {
+  if (!value) {
+    return 'Nenurodytas terminas';
+  }
+  return new Intl.DateTimeFormat('lt-LT', { dateStyle: 'medium' }).format(value);
+};
+
+const formatDateTime = (value: Date): string =>
+  new Intl.DateTimeFormat('lt-LT', { dateStyle: 'medium', timeStyle: 'short' }).format(value);
+
+const mapNotificationSeverity = (metadata: Record<string, unknown> | null | undefined, status: NotificationStatus) => {
+  const severity =
+    typeof metadata === 'object' && metadata && 'severity' in metadata && typeof metadata.severity === 'string'
+      ? metadata.severity.toLowerCase()
+      : '';
+
+  if (severity === 'critical' || severity === 'high' || severity === 'aukštas' || severity === 'kritinis') {
+    return 'kritinis';
+  }
+  if (severity === 'warning' || severity === 'medium' || severity === 'įspėjimas') {
+    return 'įspėjimas';
+  }
+
+  if (status === NotificationStatus.FAILED) {
+    return 'kritinis';
+  }
+  if (status === NotificationStatus.PENDING) {
+    return 'įspėjimas';
+  }
+
+  return 'informacija';
+};
+
+@Injectable()
+export class DashboardService {
+  constructor(
+    private readonly hivesRepository: HivesRepository,
+    private readonly tasksService: TasksService,
+    private readonly notificationsService: NotificationsService,
+    private readonly mediaService: MediaService,
+    private readonly messagingService: MessagingService
+  ) {}
+
+  async getSnapshot(user: AuthenticatedUser): Promise<DashboardSnapshot> {
+    const [hives, tasks, notifications, mediaItems, recentComments] = await Promise.all([
+      this.hivesRepository.findAllForUser(user.userId),
+      this.tasksService.listAccessibleTasks(user),
+      this.notificationsService.listNotificationsForUser(user.userId),
+      this.mediaService.listAccessible(user),
+      this.messagingService.listRecentMessages(user)
+    ]);
+
+    const now = new Date();
+    const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+    const monthAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+
+    const openTasks = tasks.filter(
+      (task) => task.status !== TaskStatus.COMPLETED && task.status !== TaskStatus.CANCELLED
+    );
+    const completedThisWeek = tasks.filter(
+      (task) => task.status === TaskStatus.COMPLETED && task.updatedAt >= weekAgo
+    ).length;
+    const recentMediaCount = mediaItems.filter((item) => {
+      const captured = item.capturedAt ?? item.createdAt;
+      return captured ? captured >= monthAgo : false;
+    }).length;
+
+    const stats: DashboardStat[] = [
+      {
+        id: 'active-hives',
+        label: 'Aktyvūs aviliai',
+        value: formatNumber(hives.length),
+        trend: hives.length ? 'Stabilus rodiklis' : 'Pridėkite avilių',
+        trendTone: hives.length ? 'neutral' : 'negative'
+      },
+      {
+        id: 'open-tasks',
+        label: 'Atviros užduotys',
+        value: formatNumber(openTasks.length),
+        trend:
+          openTasks.length > 5
+            ? 'Didelė apkrova – peržiūrėkite prioritetus'
+            : openTasks.length
+            ? 'Tvarkoma laiku'
+            : 'Visos užduotys užbaigtos',
+        trendTone: openTasks.length > 5 ? 'negative' : openTasks.length ? 'info' : 'positive'
+      },
+      {
+        id: 'completed-week',
+        label: 'Užbaigta per 7 d.',
+        value: formatNumber(completedThisWeek),
+        trend: completedThisWeek ? 'Progresas matomas' : 'Laukiama aktyvumo',
+        trendTone: completedThisWeek ? 'positive' : 'neutral'
+      },
+      {
+        id: 'media-month',
+        label: 'Naujos medijos (30 d.)',
+        value: formatNumber(recentMediaCount),
+        trend: recentMediaCount ? 'Aktyvus dalinimasis' : 'Papildykite biblioteką',
+        trendTone: recentMediaCount ? 'positive' : 'neutral'
+      }
+    ];
+
+    const priorityTasks: DashboardTask[] = openTasks
+      .filter((task) => task.priority >= 2)
+      .sort((a, b) => {
+        if (b.priority !== a.priority) {
+          return b.priority - a.priority;
+        }
+        const aDue = a.dueDate ? a.dueDate.getTime() : Infinity;
+        const bDue = b.dueDate ? b.dueDate.getTime() : Infinity;
+        return aDue - bDue;
+      })
+      .slice(0, 5)
+      .map((task) => ({
+        id: task.id,
+        title: task.title,
+        assignedTo: task.assignedTo ? formatUserDisplayName(task.assignedTo) : 'Nepriskirta',
+        dueDate: formatDate(task.dueDate ?? null),
+        status: formatTaskStatusLabel(task.status),
+        priority: formatTaskPriorityLabel(task.priority)
+      }));
+
+    const alerts: DashboardAlert[] = notifications
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+      .slice(0, 5)
+      .map((notification) => ({
+        id: notification.id,
+        title: notification.title,
+        description: notification.body,
+        type: mapNotificationSeverity(notification.metadata, notification.status),
+        createdAt: formatDateTime(notification.createdAt)
+      }));
+
+    if (!alerts.length && recentComments.length) {
+      const comment = recentComments[0];
+      alerts.push({
+        id: `comment-${comment.id}`,
+        title: `Naujas komentaras užduočiai ${comment.task.title}`,
+        description: comment.content.length > 120 ? `${comment.content.slice(0, 117)}...` : comment.content,
+        type: 'informacija',
+        createdAt: formatDateTime(comment.createdAt)
+      });
+    }
+
+    return {
+      stats,
+      alerts,
+      tasks: priorityTasks
+    };
+  }
+}

--- a/src/dashboard/types.ts
+++ b/src/dashboard/types.ts
@@ -1,0 +1,30 @@
+export interface DashboardStat {
+  id: string;
+  label: string;
+  value: string;
+  trend: string;
+  trendTone: 'positive' | 'negative' | 'neutral' | 'info';
+}
+
+export interface DashboardAlert {
+  id: string;
+  title: string;
+  description: string;
+  type: 'įspėjimas' | 'informacija' | 'kritinis';
+  createdAt: string;
+}
+
+export interface DashboardTask {
+  id: string;
+  title: string;
+  assignedTo: string;
+  dueDate: string;
+  status: string;
+  priority: string;
+}
+
+export interface DashboardSnapshot {
+  stats: DashboardStat[];
+  alerts: DashboardAlert[];
+  tasks: DashboardTask[];
+}

--- a/src/media/media.service.ts
+++ b/src/media/media.service.ts
@@ -39,6 +39,13 @@ export class MediaService {
     return this.mediaRepository.findByUploader(user.userId);
   }
 
+  async listAccessible(user: AuthenticatedUser): Promise<MediaItem[]> {
+    if (user.roles.includes('admin')) {
+      return this.mediaRepository.findAllWithRelations();
+    }
+    return this.mediaRepository.findAccessible(user.userId);
+  }
+
   async create(user: AuthenticatedUser, dto: CreateMediaItemDto): Promise<MediaItem> {
     const media = await this.dataSource.transaction(async (manager) => {
       const hive = await this.hivesRepository.findById(dto.hiveId, manager);

--- a/src/messaging/messaging.controller.ts
+++ b/src/messaging/messaging.controller.ts
@@ -5,6 +5,7 @@ import { RolesGuard } from '../auth/guards/roles.guard';
 import { CreateCommentDto } from './dto/create-comment.dto';
 import { Comment } from './comment.entity';
 import { MessagingService } from './messaging.service';
+import { formatUserDisplayName } from '../tasks/task.presenter';
 
 interface CommentResponse {
   id: string;
@@ -26,10 +27,53 @@ function mapComment(comment: Comment): CommentResponse {
   };
 }
 
+interface MessageFeedResponse {
+  id: string;
+  task: { id: string; title: string; hiveId: string; hiveName: string };
+  author: {
+    id: string;
+    email: string;
+    roles: string[];
+    firstName?: string;
+    lastName?: string;
+    displayName: string;
+  };
+  content: string;
+  createdAt: string;
+  isOwn: boolean;
+}
+
+function mapMessage(comment: Comment, currentUserId: string): MessageFeedResponse {
+  const task = comment.task!;
+  const hive = task.hive!;
+  const author = comment.author;
+  return {
+    id: comment.id,
+    task: { id: task.id, title: task.title, hiveId: hive.id, hiveName: hive.name },
+    author: {
+      id: author.id,
+      email: author.email,
+      roles: author.roles,
+      firstName: author.firstName,
+      lastName: author.lastName,
+      displayName: formatUserDisplayName(author)
+    },
+    content: comment.content,
+    createdAt: comment.createdAt.toISOString(),
+    isOwn: author.id === currentUserId
+  };
+}
+
 @Controller()
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class MessagingController {
   constructor(private readonly messagingService: MessagingService) {}
+
+  @Get('messages')
+  async listMessages(@CurrentUser() user: AuthenticatedUser): Promise<MessageFeedResponse[]> {
+    const comments = await this.messagingService.listRecentMessages(user);
+    return comments.map((comment) => mapMessage(comment, user.userId));
+  }
 
   @Get('tasks/:taskId/comments')
   async listComments(

--- a/src/tasks/task.presenter.ts
+++ b/src/tasks/task.presenter.ts
@@ -1,0 +1,102 @@
+import { Task } from './task.entity';
+import { TaskStatus } from './task-status.enum';
+
+export interface TaskUserPresenter {
+  id: string;
+  email: string;
+  roles: string[];
+  firstName?: string;
+  lastName?: string;
+  displayName: string;
+}
+
+export interface TaskPresenter {
+  id: string;
+  title: string;
+  description?: string;
+  status: TaskStatus;
+  statusLabel: string;
+  priority: number;
+  priorityLabel: string;
+  dueDate: string | null;
+  inspectionId?: string;
+  templateId?: string;
+  hive: { id: string; name: string };
+  assignedTo?: TaskUserPresenter | null;
+  createdBy: TaskUserPresenter;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const TASK_STATUS_LABELS: Record<TaskStatus, string> = {
+  [TaskStatus.PENDING]: 'laukiama',
+  [TaskStatus.IN_PROGRESS]: 'vykdoma',
+  [TaskStatus.COMPLETED]: 'užbaigta',
+  [TaskStatus.BLOCKED]: 'kritinė',
+  [TaskStatus.CANCELLED]: 'atšaukta'
+};
+
+export const formatTaskStatusLabel = (status: TaskStatus): string => TASK_STATUS_LABELS[status] ?? status;
+
+export const formatTaskPriorityLabel = (priority: number): string => {
+  if (priority >= 3) {
+    return 'aukšta';
+  }
+  if (priority === 2) {
+    return 'vidutinė';
+  }
+  return 'žema';
+};
+
+export const formatUserDisplayName = (user: {
+  firstName?: string;
+  lastName?: string;
+  email: string;
+}): string => {
+  const parts = [user.firstName, user.lastName].filter((part) => part && part.trim());
+  if (parts.length) {
+    return parts.join(' ');
+  }
+  return user.email;
+};
+
+const mapUser = (user: {
+  id: string;
+  email: string;
+  roles: string[];
+  firstName?: string;
+  lastName?: string;
+} | null | undefined): TaskUserPresenter | null => {
+  if (!user) {
+    return null;
+  }
+
+  return {
+    id: user.id,
+    email: user.email,
+    roles: user.roles,
+    firstName: user.firstName,
+    lastName: user.lastName,
+    displayName: formatUserDisplayName(user)
+  };
+};
+
+export const toTaskPresenter = (task: Task): TaskPresenter => ({
+  id: task.id,
+  title: task.title,
+  description: task.description ?? undefined,
+  status: task.status,
+  statusLabel: formatTaskStatusLabel(task.status),
+  priority: task.priority,
+  priorityLabel: formatTaskPriorityLabel(task.priority),
+  dueDate: task.dueDate ? task.dueDate.toISOString() : null,
+  inspectionId: task.inspectionId ?? undefined,
+  templateId: task.templateId ?? undefined,
+  hive: { id: task.hive.id, name: task.hive.name },
+  assignedTo: mapUser(task.assignedTo),
+  createdBy: mapUser(task.createdBy)!,
+  createdAt: task.createdAt.toISOString(),
+  updatedAt: task.updatedAt.toISOString()
+});
+
+export const toTaskPresenterList = (tasks: Task[]): TaskPresenter[] => tasks.map(toTaskPresenter);

--- a/src/tasks/tasks.repository.ts
+++ b/src/tasks/tasks.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { EntityManager, Repository } from 'typeorm';
+import { Brackets, EntityManager, Repository } from 'typeorm';
 import { Task } from './task.entity';
 
 @Injectable()
@@ -39,5 +39,35 @@ export class TasksRepository {
       relations: ['hive', 'assignedTo', 'createdBy'],
       order: { createdAt: 'DESC' }
     });
+  }
+
+  findAllWithRelations(): Promise<Task[]> {
+    return this.repository.find({
+      relations: ['hive', 'assignedTo', 'createdBy', 'hive.owner', 'hive.members'],
+      order: { priority: 'DESC', dueDate: 'ASC', createdAt: 'DESC' }
+    });
+  }
+
+  findAccessible(userId: string): Promise<Task[]> {
+    return this.repository
+      .createQueryBuilder('task')
+      .leftJoinAndSelect('task.hive', 'hive')
+      .leftJoinAndSelect('task.assignedTo', 'assignedTo')
+      .leftJoinAndSelect('task.createdBy', 'createdBy')
+      .leftJoinAndSelect('hive.owner', 'owner')
+      .leftJoinAndSelect('hive.members', 'member')
+      .where(
+        new Brackets((qb) => {
+          qb.where('owner.id = :userId', { userId })
+            .orWhere('member.id = :userId', { userId })
+            .orWhere('assignedTo.id = :userId', { userId })
+            .orWhere('createdBy.id = :userId', { userId });
+        })
+      )
+      .orderBy('task.priority', 'DESC')
+      .addOrderBy('task.dueDate', 'ASC')
+      .addOrderBy('task.createdAt', 'DESC')
+      .distinct(true)
+      .getMany();
   }
 }

--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -29,6 +29,13 @@ export class TasksService {
     private readonly dataSource: DataSource
   ) {}
 
+  async listAccessibleTasks(user: AuthenticatedUser): Promise<Task[]> {
+    if (user.roles.includes('admin')) {
+      return this.tasksRepository.findAllWithRelations();
+    }
+    return this.tasksRepository.findAccessible(user.userId);
+  }
+
   async listTasksForHive(user: AuthenticatedUser, hiveId: string): Promise<Task[]> {
     const hive = await this.hivesRepository.findById(hiveId);
     if (!hive) {

--- a/src/users/__tests__/users.service.spec.ts
+++ b/src/users/__tests__/users.service.spec.ts
@@ -1,6 +1,11 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as bcrypt from 'bcryptjs';
+
+jest.mock('bcryptjs', () => ({
+  hash: jest.fn(),
+  compare: jest.fn()
+}));
 import { CreateUserDto } from '../dto/create-user.dto';
 import { UpdateUserDto } from '../dto/update-user.dto';
 import { User } from '../user.entity';
@@ -58,7 +63,8 @@ describe('UsersService', () => {
         isActive: true
       } as unknown as User;
 
-      jest.spyOn(bcrypt, 'hash').mockResolvedValue('hashed-password');
+      const hashSpy = bcrypt.hash as jest.MockedFunction<typeof bcrypt.hash>;
+      hashSpy.mockResolvedValue('hashed-password' as never);
       repository.findByEmail.mockResolvedValue(null);
       repository.create.mockReturnValue(createdUser);
       repository.save.mockResolvedValue(createdUser);


### PR DESCRIPTION
## Summary
- add a Dashboard module that aggregates stats, alerts, and priority tasks for `/dashboard`
- expose new `/tasks`, `/media`, and `/messages` endpoints and shared presenters for localized task/media data
- update the React dashboard, tasks, media, and messaging pages (and tests) to consume the new APIs with Lithuanian labels

## Testing
- npm test
- npm run test:web *(fails: vitest binary missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d249640d3c833397b6f4bb888e21b0