### PR TITLE
Align web notifications and user directory with API

### DIFF
--- a/apps/web/src/features/dashboard/DashboardPage.tsx
+++ b/apps/web/src/features/dashboard/DashboardPage.tsx
@@ -4,15 +4,15 @@ import { StatusBadge } from "../../components/ui/StatusBadge";
 import { BellAlertIcon, ClipboardDocumentCheckIcon } from "@heroicons/react/24/outline";
 import { useQuery } from "@tanstack/react-query";
 import { apiClient } from "../../lib/apiClient";
-import type { DashboardStat, Notification, Task } from "../../types";
+import type { DashboardAlert, DashboardStat, Task } from "../../types";
 
 export type DashboardSnapshot = {
   stats: DashboardStat[];
-  alerts: Notification[];
+  alerts: DashboardAlert[];
   tasks: Task[];
 };
 
-const statusToneMap: Record<string, "success" | "warning" | "danger" | "info"> = {
+const statusToneMap: Record<DashboardAlert["type"], "success" | "warning" | "danger" | "info"> = {
   įspėjimas: "warning",
   informacija: "info",
   kritinis: "danger"

--- a/apps/web/src/features/users/UsersPage.tsx
+++ b/apps/web/src/features/users/UsersPage.tsx
@@ -2,21 +2,139 @@ import { Card } from "../../components/ui/Card";
 import { StatusBadge } from "../../components/ui/StatusBadge";
 import { useQuery } from "@tanstack/react-query";
 import { apiClient } from "../../lib/apiClient";
-import type { TeamMember } from "../../types";
+import type { User } from "../../types";
+
+const avatarPalette = [
+  "bg-amber-400 text-amber-950",
+  "bg-sky-400 text-sky-950",
+  "bg-emerald-400 text-emerald-950",
+  "bg-rose-400 text-rose-950",
+  "bg-indigo-400 text-indigo-50",
+  "bg-lime-300 text-lime-900"
+];
+
+const hashString = (value: string) => {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash << 5) - hash + value.charCodeAt(index);
+    hash |= 0; // keep a 32bit value
+  }
+
+  return Math.abs(hash);
+};
+
+const resolveAvatarColor = (seed: string) => {
+  const paletteIndex = hashString(seed) % avatarPalette.length;
+  return avatarPalette[paletteIndex];
+};
+
+const getFullName = (user: User) => {
+  const first = user.firstName?.trim() ?? "";
+  const last = user.lastName?.trim() ?? "";
+  const combined = `${first} ${last}`.trim();
+  return combined || user.email;
+};
+
+const getInitials = (name: string) => {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (!parts.length) {
+    return "?";
+  }
+
+  if (parts.length === 1) {
+    return parts[0].slice(0, 2).toUpperCase();
+  }
+
+  const first = parts[0]?.[0] ?? "";
+  const last = parts[parts.length - 1]?.[0] ?? "";
+  return `${first}${last}`.toUpperCase();
+};
+
+const formatContact = (user: User) => user.phoneNumber?.trim() || user.email;
+
+const formatActiveSince = (value: string) => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat("lt-LT", {
+    dateStyle: "long"
+  }).format(date);
+};
+
+const formatRoles = (roles: string[]) => {
+  if (!roles.length) {
+    return "Rolė nenurodyta";
+  }
+
+  return roles.join(", ");
+};
 
 const UsersPage = () => {
   const {
-    data: members,
-    isLoading,
-    isError,
-    error
-  } = useQuery<TeamMember[]>({
-    queryKey: ["users"],
-    queryFn: () => apiClient.get<TeamMember[]>("/users"),
+    data: currentUser,
+    isLoading: isLoadingMe,
+    isError: isErrorMe,
+    error: errorMe
+  } = useQuery<User>({
+    queryKey: ["users", "me"],
+    queryFn: () => apiClient.get<User>("/users/me"),
     staleTime: 60_000
   });
 
-  const team = members ?? [];
+  const isAdmin = Boolean(currentUser?.roles.includes("admin"));
+
+  const {
+    data: directory,
+    isLoading: isLoadingDirectory,
+    isError: isDirectoryError,
+    error: directoryError
+  } = useQuery<User[]>({
+    queryKey: ["users", "directory"],
+    queryFn: () => apiClient.get<User[]>("/users"),
+    enabled: isAdmin,
+    staleTime: 60_000
+  });
+
+  const isLoading = isLoadingMe || (isAdmin && isLoadingDirectory && !directory);
+
+  const members = !isAdmin
+    ? currentUser
+      ? [currentUser]
+      : []
+    : directory
+    ? directory
+    : currentUser
+    ? [currentUser]
+    : [];
+
+  const directoryErrorMessage =
+    (isErrorMe && (errorMe instanceof Error ? errorMe.message : "Nepavyko įkelti profilio.")) ||
+    (isAdmin && isDirectoryError
+      ? directoryError instanceof Error
+        ? directoryError.message
+        : "Nepavyko įkelti komandos narių."
+      : "");
+
+  const hasMembers = members.length > 0;
+  const allActive = hasMembers && members.every((member) => member.isActive);
+
+  const statusBadgeTone: "success" | "warning" | "danger" | "info" | "neutral" = isLoading
+    ? "neutral"
+    : !hasMembers
+    ? "neutral"
+    : allActive
+    ? "success"
+    : "warning";
+
+  const statusBadgeLabel = isLoading
+    ? "Kraunama..."
+    : !hasMembers
+    ? "Komandos duomenų nėra"
+    : allActive
+    ? "Visa komanda aktyvi"
+    : "Yra neaktyvių narių";
 
   return (
     <div className="space-y-6">
@@ -27,7 +145,7 @@ const UsersPage = () => {
             Rolėmis paremtos prieigos užtikrins, kad kiekvienas matys tik jam skirtus modulius.
           </p>
         </div>
-        <StatusBadge tone="success">Visa komanda aktyvi</StatusBadge>
+        <StatusBadge tone={statusBadgeTone}>{statusBadgeLabel}</StatusBadge>
       </div>
 
       <div className="grid gap-4 md:grid-cols-2">
@@ -35,34 +153,63 @@ const UsersPage = () => {
           <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6 text-sm text-slate-400">
             Kraunama komandos informacija...
           </div>
-        ) : isError ? (
-          <div className="rounded-2xl border border-rose-500/40 bg-rose-500/10 p-6 text-sm text-rose-200">
-            {error instanceof Error ? error.message : "Nepavyko įkelti komandos narių."}
-          </div>
         ) : (
-          team.map((member) => (
-            <Card
-              key={member.id}
-              title={member.name}
-              subtitle={`Komandoje nuo ${member.activeSince}`}
-              accent={<span className="text-xs text-slate-400">{member.contact}</span>}
-            >
-              <div className="flex items-center gap-4">
-                <div className={`flex h-12 w-12 items-center justify-center rounded-full text-lg font-semibold text-slate-900 ${member.avatarColor}`}>
-                  {member.name
-                    .split(" ")
-                    .map((part) => part[0])
-                    .join("")}
-                </div>
-                <div>
-                  <p className="text-sm font-semibold text-slate-100">{member.role}</p>
-                  <p className="mt-1 text-xs text-slate-400">
-                    Prisijungimų statistika ir aktyvumo žemėlapis bus pasiekiami integravus autentifikaciją.
+          <>
+            {directoryErrorMessage ? (
+              <div className="rounded-2xl border border-rose-500/40 bg-rose-500/10 p-6 text-sm text-rose-200">
+                <p>{directoryErrorMessage}</p>
+                {hasMembers ? (
+                  <p className="mt-2 text-xs text-rose-100/80">
+                    Rodomi paskutiniai turimi komandos duomenys.
                   </p>
-                </div>
+                ) : null}
               </div>
-            </Card>
-          ))
+            ) : null}
+
+            {hasMembers ? (
+              members.map((member) => {
+                const fullName = getFullName(member);
+                const initials = getInitials(fullName);
+                const avatarColor = resolveAvatarColor(member.id ?? fullName);
+                const contact = formatContact(member);
+                const activeSince = formatActiveSince(member.createdAt);
+                const subtitle = activeSince ? `Komandoje nuo ${activeSince}` : "Komandos nario informacija";
+
+                return (
+                  <Card
+                    key={member.id}
+                    title={fullName}
+                    subtitle={subtitle}
+                    accent={
+                      <span className="text-xs text-slate-400">
+                        {contact || "Kontaktinė informacija nenurodyta"}
+                      </span>
+                    }
+                  >
+                    <div className="flex items-center gap-4">
+                      <div
+                        className={`flex h-12 w-12 items-center justify-center rounded-full text-lg font-semibold ${avatarColor}`}
+                      >
+                        {initials}
+                      </div>
+                      <div>
+                        <p className="text-sm font-semibold text-slate-100">{formatRoles(member.roles)}</p>
+                        <p className="mt-1 text-xs text-slate-400">
+                          {member.isActive
+                            ? "Aktyvus narys su pilna prieiga."
+                            : "Prieiga išjungta administratoriaus."}
+                        </p>
+                      </div>
+                    </div>
+                  </Card>
+                );
+              })
+            ) : !directoryErrorMessage ? (
+              <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6 text-sm text-slate-400">
+                Komandos narių dar nėra.
+              </div>
+            ) : null}
+          </>
         )}
       </div>
     </div>

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -27,12 +27,37 @@ export type Message = {
   unread?: boolean;
 };
 
+export type NotificationChannel = "IN_APP" | "EMAIL" | "SMS" | "PUSH";
+
+export type NotificationStatus = "PENDING" | "SENT" | "FAILED" | "READ";
+
+export type NotificationDeliveryDetail = {
+  status: NotificationStatus;
+  attempts: number;
+  lastAttemptAt: string;
+  providerMessageId?: string;
+  lastError?: string;
+  extra?: Record<string, unknown>;
+};
+
+export type NotificationDeliveryMap = Partial<Record<NotificationChannel, NotificationDeliveryDetail>>;
+
 export type Notification = {
   id: string;
   title: string;
-  description: string;
-  type: "įspėjimas" | "informacija" | "kritinis";
+  body: string;
+  channel: NotificationChannel;
+  status: NotificationStatus;
+  metadata: Record<string, unknown> | null;
+  relatedTaskId?: string;
+  relatedInspectionId?: string;
+  relatedHarvestId?: string;
+  auditEventId?: string;
+  sentAt: string | null;
+  readAt: string | null;
   createdAt: string;
+  updatedAt: string;
+  deliveryMetadata: NotificationDeliveryMap | null;
 };
 
 export type MediaItem = {
@@ -44,13 +69,24 @@ export type MediaItem = {
   tags: string[];
 };
 
-export type TeamMember = {
+export type User = {
   id: string;
-  name: string;
-  role: string;
-  contact: string;
-  activeSince: string;
-  avatarColor: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  phoneNumber: string | null;
+  roles: string[];
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type DashboardAlert = {
+  id: string;
+  title: string;
+  description: string;
+  type: "įspėjimas" | "informacija" | "kritinis";
+  createdAt: string;
 };
 
 export type AuditLogEntry = {


### PR DESCRIPTION
## Summary
- derive localized notification labels in the web client from notification status and channel metadata
- update the team directory to use /users/me and admin-only listings while composing display details from the available fields
- refresh shared notification/user/dashboard types to match the API contract and update dependent components

## Testing
- npm run lint:web *(fails: missing typescript-eslint package in lint configuration)*
- npm run test:web *(fails: vitest prompts for installing jsdom dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68d2496892588333ba0ff82921cadd1d