### PR TITLE
Map SafeUser responses for users page

### DIFF
--- a/apps/web/src/features/users/UsersPage.test.tsx
+++ b/apps/web/src/features/users/UsersPage.test.tsx
@@ -1,0 +1,84 @@
+import type { ReactElement } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import UsersPage from "./UsersPage";
+import { ApiClientError, apiClient } from "../../lib/apiClient";
+import type { SafeUser } from "../../types";
+
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false
+      }
+    }
+  });
+
+let testQueryClient: QueryClient | null = null;
+
+const renderWithClient = (ui: ReactElement) => {
+  const client = createTestQueryClient();
+  testQueryClient = client;
+
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+};
+
+describe("UsersPage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    testQueryClient?.clear();
+    testQueryClient = null;
+  });
+
+  it("renders team members returned by the API", async () => {
+    const users: SafeUser[] = [
+      {
+        id: "user-1",
+        email: "ada@example.com",
+        firstName: "Ada",
+        lastName: "Lovelace",
+        phoneNumber: "+37060000001",
+        roles: ["admin"],
+        isActive: true,
+        createdAt: new Date("2024-01-05T08:45:00.000Z").toISOString(),
+        updatedAt: new Date("2024-01-10T08:45:00.000Z").toISOString()
+      }
+    ];
+
+    const spy = vi.spyOn(apiClient, "get").mockResolvedValue(users);
+
+    renderWithClient(<UsersPage />);
+
+    await waitFor(() => expect(screen.getByText("Ada Lovelace")).toBeInTheDocument());
+
+    expect(screen.getByText("Administratorius")).toBeInTheDocument();
+    expect(screen.getByText("ada@example.com • +37060000001")).toBeInTheDocument();
+    expect(screen.getByText(/Komandoje nuo/)).toBeInTheDocument();
+    expect(spy).toHaveBeenCalledWith("/users");
+  });
+
+  it("shows a friendly access message when the request is forbidden", async () => {
+    const error = new ApiClientError("Forbidden", 403, null);
+    vi.spyOn(apiClient, "get").mockRejectedValue(error);
+
+    renderWithClient(<UsersPage />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          /Ši sritis prieinama tik administratoriams. Susisiekite su sistemos administratoriumi dėl prieigos\./i
+        )
+      ).toBeInTheDocument()
+    );
+  });
+
+  it("displays server error messages for other failures", async () => {
+    const error = new ApiClientError("Įvyko klaida", 500, null);
+    vi.spyOn(apiClient, "get").mockRejectedValue(error);
+
+    renderWithClient(<UsersPage />);
+
+    await waitFor(() => expect(screen.getByText("Įvyko klaida")).toBeInTheDocument());
+  });
+});

--- a/apps/web/src/features/users/userMapper.test.ts
+++ b/apps/web/src/features/users/userMapper.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { mapSafeUserToTeamMember, mapSafeUsersToTeamMembers } from "./userMapper";
+import type { SafeUser } from "../../types";
+
+describe("mapSafeUserToTeamMember", () => {
+  const baseUser: SafeUser = {
+    id: "user-1",
+    email: "ada@example.com",
+    firstName: "Ada",
+    lastName: "Lovelace",
+    phoneNumber: "+37060000001",
+    roles: ["admin", "keeper"],
+    isActive: true,
+    createdAt: new Date("2024-01-05T08:45:00.000Z").toISOString(),
+    updatedAt: new Date("2024-01-10T08:45:00.000Z").toISOString()
+  };
+
+  it("maps API payloads into the team member view model", () => {
+    const member = mapSafeUserToTeamMember(baseUser);
+
+    expect(member.id).toBe("user-1");
+    expect(member.name).toBe("Ada Lovelace");
+    expect(member.role).toBe("Administratorius");
+    expect(member.contact).toBe("ada@example.com • +37060000001");
+    expect(member.activeSince).toBe(
+      new Intl.DateTimeFormat("lt-LT", { dateStyle: "medium" }).format(
+        new Date(baseUser.createdAt)
+      )
+    );
+    expect(member.avatarColor).toMatch(/^bg-/);
+  });
+
+  it("falls back to safe defaults when profile details are missing", () => {
+    const payload: SafeUser = {
+      ...baseUser,
+      id: "user-2",
+      email: "no-name@example.com",
+      firstName: null,
+      lastName: " ",
+      phoneNumber: null,
+      roles: [],
+      createdAt: "not-a-date"
+    };
+
+    const member = mapSafeUserToTeamMember(payload);
+
+    expect(member.name).toBe("no-name@example.com");
+    expect(member.role).toBe("Nenurodyta rolė");
+    expect(member.contact).toBe("no-name@example.com");
+    expect(member.activeSince).toBe("nežinoma");
+  });
+
+  it("produces deterministic avatar colors based on the user identifier", () => {
+    const first = mapSafeUserToTeamMember(baseUser);
+    const second = mapSafeUserToTeamMember({ ...baseUser });
+    const others = mapSafeUsersToTeamMembers([
+      baseUser,
+      { ...baseUser, id: "user-99", email: "alt@example.com" }
+    ]);
+
+    expect(first.avatarColor).toBe(second.avatarColor);
+    expect(others[0].avatarColor).not.toBe(others[1].avatarColor);
+  });
+});

--- a/apps/web/src/features/users/userMapper.ts
+++ b/apps/web/src/features/users/userMapper.ts
@@ -1,0 +1,103 @@
+import type { SafeUser, TeamMember } from "../../types";
+
+const ROLE_LABELS: Record<string, string> = {
+  admin: "Administratorius",
+  keeper: "Prižiūrėtojas",
+  analyst: "Analitikas",
+  inspector: "Inspektorius",
+  viewer: "Stebėtojas",
+  auditor: "Auditorius"
+};
+
+const AVATAR_COLORS = [
+  "bg-amber-300",
+  "bg-emerald-300",
+  "bg-sky-300",
+  "bg-fuchsia-300",
+  "bg-rose-300",
+  "bg-lime-300",
+  "bg-cyan-300",
+  "bg-violet-300"
+] as const;
+
+const toTitleCase = (value: string) =>
+  value
+    .toLowerCase()
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+
+const pickPrimaryRole = (roles: string[]) => {
+  const primary = roles.find((role) => typeof role === "string" && role.trim().length > 0);
+  if (!primary) {
+    return "Nenurodyta rolė";
+  }
+
+  const normalized = primary.trim().toLowerCase();
+  if (ROLE_LABELS[normalized]) {
+    return ROLE_LABELS[normalized];
+  }
+
+  return toTitleCase(primary.trim());
+};
+
+const buildFullName = (firstName: string | null, lastName: string | null, email: string) => {
+  const parts = [firstName, lastName]
+    .map((part) => part?.trim())
+    .filter((part): part is string => Boolean(part && part.length > 0));
+
+  if (parts.length > 0) {
+    return parts.join(" ");
+  }
+
+  return email;
+};
+
+const buildContactLabel = (email: string, phoneNumber: string | null) => {
+  const phone = phoneNumber?.trim();
+  if (phone && phone.length > 0) {
+    return `${email} • ${phone}`;
+  }
+
+  return email;
+};
+
+const formatActiveSince = (timestamp: string) => {
+  const parsed = new Date(timestamp);
+  if (Number.isNaN(parsed.getTime())) {
+    return "nežinoma";
+  }
+
+  return new Intl.DateTimeFormat("lt-LT", { dateStyle: "medium" }).format(parsed);
+};
+
+const hashString = (value: string) => {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash << 5) - hash + value.charCodeAt(index);
+    hash |= 0; // Convert to 32bit integer
+  }
+  return Math.abs(hash);
+};
+
+const selectAvatarColor = (seed: string) => {
+  const safeSeed = seed && seed.trim().length > 0 ? seed : "default";
+  const hash = hashString(safeSeed);
+  const colorIndex = hash % AVATAR_COLORS.length;
+  return AVATAR_COLORS[colorIndex];
+};
+
+export const mapSafeUserToTeamMember = (user: SafeUser): TeamMember => ({
+  id: user.id,
+  name: buildFullName(user.firstName, user.lastName, user.email),
+  role: pickPrimaryRole(user.roles),
+  contact: buildContactLabel(user.email, user.phoneNumber),
+  activeSince: formatActiveSince(user.createdAt),
+  avatarColor: selectAvatarColor(user.id || user.email)
+});
+
+export const mapSafeUsersToTeamMembers = (users: SafeUser[]): TeamMember[] =>
+  users.map((user) => mapSafeUserToTeamMember(user));
+
+export type { TeamMember };

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -13,6 +13,18 @@ export type HiveUserSummary = {
   roles: string[];
 };
 
+export type SafeUser = {
+  id: string;
+  email: string;
+  firstName: string | null;
+  lastName: string | null;
+  phoneNumber: string | null;
+  roles: string[];
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
 export type Hive = {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary
- request SafeUser records from the users endpoint and map them into the view model with deterministic avatar colors
- surface an admin-only access message when the listing is forbidden and define shared SafeUser typings
- add mapper and UsersPage component tests to cover the new transformations and error states

## Testing
- CI=1 npm --prefix apps/web run test *(fails: missing optional dependency `jsdom` in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d259e103bc83338fa002b493365f36