### PR TITLE
Fix Firebase private key newline sanitization test

### DIFF
--- a/src/notifications/notifications.module.spec.ts
+++ b/src/notifications/notifications.module.spec.ts
@@ -67,7 +67,7 @@ describe('firebase messaging provider', () => {
     expect(mockApp.cert).toHaveBeenCalledTimes(1);
 
     const [credentials] = mockApp.cert.mock.calls[0] as [{ privateKey: string }];
-    expect(credentials.privateKey).toContain('\n');
+    expect(credentials.privateKey).toBe('line-one\nline-two');
     expect(credentials.privateKey).not.toContain('\\n');
   });
 });

--- a/src/notifications/notifications.module.ts
+++ b/src/notifications/notifications.module.ts
@@ -45,7 +45,7 @@ const firebaseMessagingProvider = {
     }
 
     try {
-      // Convert escaped '\n' sequences into actual line breaks for Firebase credentials.
+      // Convert escaped '\n' sequences (single backslash) into actual line breaks for Firebase credentials.
       const sanitizedPrivateKey = privateKey.replace(/\\n/g, '\n');
       const existing = getApps().find((app) => app.name === 'busmedaus-notifications');
       const app =


### PR DESCRIPTION
## Summary
- clarify the Firebase notifications module comment to call out single `\n` escape handling
- update the notifications module spec to assert the sanitized private key contains a real newline rather than a literal `\n`

## Testing
- npm test -- notifications

------
https://chatgpt.com/codex/tasks/task_e_68d268cd82388333b65a736a730dae1e