### PR TITLE
Handle single escaped newlines in notifications private key

### DIFF
--- a/src/notifications/notifications.module.spec.ts
+++ b/src/notifications/notifications.module.spec.ts
@@ -67,7 +67,9 @@ describe('firebase messaging provider', () => {
     expect(mockApp.cert).toHaveBeenCalledTimes(1);
 
     const [credentials] = mockApp.cert.mock.calls[0] as [{ privateKey: string }];
-    expect(credentials.privateKey).toBe('line-one\nline-two');
+    const expectedSanitizedKey = ['line-one', 'line-two'].join('\n');
+    expect(credentials.privateKey).toBe(expectedSanitizedKey);
+    expect(credentials.privateKey).toContain('\n');
     expect(credentials.privateKey).not.toContain('\\n');
   });
 });

--- a/src/notifications/notifications.module.ts
+++ b/src/notifications/notifications.module.ts
@@ -45,7 +45,8 @@ const firebaseMessagingProvider = {
     }
 
     try {
-      // Convert escaped '\n' sequences (single backslash) into actual line breaks for Firebase credentials.
+      // Convert escaped '\n' sequences (single backslash) into actual line breaks for Firebase credentials
+      // before passing them to the Firebase admin SDK.
       const sanitizedPrivateKey = privateKey.replace(/\\n/g, '\n');
       const existing = getApps().find((app) => app.name === 'busmedaus-notifications');
       const app =


### PR DESCRIPTION
## Summary
- document that Firebase private keys now replace escaped `\n` sequences with actual newlines before credential creation
- expand the notifications module spec to assert that sanitized keys contain real newline characters and no literal `\n`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d270469254833383411fc2e02c6e20