### PR TITLE
Stop passing metadata to router <Route> elements

### DIFF
--- a/apps/web/src/routes/AppRoutes.tsx
+++ b/apps/web/src/routes/AppRoutes.tsx
@@ -16,8 +16,14 @@ export const AppRoutes = () => {
   return (
     <Suspense fallback={<LoadingState label="Įkeliame modulį" />}>
       <Routes>
-        {appRoutes.map((route) => (
-          <Route key={route.id} {...route} />
+        {appRoutes.map(({
+          id,
+          icon: _icon,
+          label: _label,
+          description: _description,
+          ...routeProps
+        }) => (
+          <Route key={id} {...routeProps} />
         ))}
         <Route path="*" element={<NotFound />} />
       </Routes>

--- a/apps/web/src/routes/routeConfig.tsx
+++ b/apps/web/src/routes/routeConfig.tsx
@@ -8,10 +8,10 @@ import {
   BellAlertIcon,
   ShieldCheckIcon
 } from "@heroicons/react/24/outline";
-import type { RouteObject } from "react-router-dom";
+import type { PathRouteProps } from "react-router-dom";
 import { lazy, type SVGProps } from "react";
 
-export type AppRoute = RouteObject & {
+export type AppRoute = PathRouteProps & {
   id: string;
   label: string;
   description: string;


### PR DESCRIPTION
## Summary
- stop spreading custom metadata onto `<Route>` elements by omitting id/label/description/icon during render
- narrow the `AppRoute` type to `PathRouteProps` so the remaining props line up with the router component API

## Testing
- `npx tsc -p apps/web/tsconfig.app.json`
- `npm --prefix apps/web run build` *(fails: PostCSS config is written as ESM and Node cannot import it under the current CommonJS settings)*

------
https://chatgpt.com/codex/tasks/task_e_68d28312831c833397a8751855a92dcb