### PR TITLE
fix seeder TaskStatus import

### DIFF
--- a/src/database/seed.ts
+++ b/src/database/seed.ts
@@ -2,7 +2,8 @@ import 'reflect-metadata';
 import { AppDataSource } from './data-source';
 import { User } from '../users/user.entity';
 import { Hive, HiveStatus } from '../hives/hive.entity';
-import { Task, TaskStatus } from '../tasks/task.entity';
+import { Task } from '../tasks/task.entity';
+import { TaskStatus } from '../tasks/task-status.enum';
 import {
   Notification,
   NotificationChannel,


### PR DESCRIPTION
## Summary
- update the database seeder to import TaskStatus from the shared enum module so it matches the rest of the codebase

## Testing
- npx tsc -p tsconfig.json

------
https://chatgpt.com/codex/tasks/task_e_68d284c94c4083339b369ffb907556f5