### PR TITLE
Implement messaging thread view and composer

### DIFF
--- a/apps/web/src/features/messaging/MessagingPage.test.tsx
+++ b/apps/web/src/features/messaging/MessagingPage.test.tsx
@@ -1,9 +1,10 @@
 import type { ReactElement } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import MessagingPage from "./MessagingPage";
-import { apiClient } from "../../lib/apiClient";
+import { ApiClientError, apiClient } from "../../lib/apiClient";
 
 const createTestQueryClient = () =>
   new QueryClient({
@@ -30,8 +31,9 @@ describe("MessagingPage", () => {
     testQueryClient = null;
   });
 
-  it("shows localized messaging entries", async () => {
-    const payload = [
+  it("renders the conversation timeline for the active task", async () => {
+    const now = new Date().toISOString();
+    const messageResponse = [
       {
         id: "msg-1",
         task: { id: "task-1", title: "Ventiliacija", hiveId: "hive-1", hiveName: "A1" },
@@ -44,19 +46,172 @@ describe("MessagingPage", () => {
           displayName: ""
         },
         content: "Patikrinkite ventiliaciją asap",
-        createdAt: new Date().toISOString(),
+        createdAt: now,
         isOwn: false
       }
     ];
+    const commentsResponse = [
+      {
+        id: "comment-1",
+        content: "Atliksiu šį darbą rytoj ryte.",
+        author: {
+          id: "user-3",
+          email: "jonas@example.com",
+          roles: ["keeper"]
+        },
+        createdAt: now
+      }
+    ];
 
-    const spy = vi.spyOn(apiClient, "get").mockResolvedValue(payload);
+    const getSpy = vi.spyOn(apiClient, "get").mockImplementation(async (path: string) => {
+      if (path === "/messages") {
+        return messageResponse as unknown as Promise<unknown>;
+      }
+      if (path === "/tasks/task-1/comments") {
+        return commentsResponse as unknown as Promise<unknown>;
+      }
+      throw new Error(`Unexpected path: ${path}`);
+    });
 
     renderWithClient(<MessagingPage />);
 
-    await waitFor(() => expect(screen.getByText("Ieva Medune")).toBeInTheDocument());
-    expect(screen.getByText(/Patikrinkite ventiliaciją asap/)).toBeInTheDocument();
-    expect(screen.getByText(/Programėlė/)).toBeInTheDocument();
-    expect(screen.getByText(/nauja/i)).toBeInTheDocument();
-    expect(spy).toHaveBeenCalledWith("/messages");
+    await waitFor(() => expect(screen.getByText("Ventiliacija")).toBeInTheDocument());
+    expect(screen.getByText("Atliksiu šį darbą rytoj ryte.")).toBeInTheDocument();
+    expect(screen.getByText("jonas@example.com")).toBeInTheDocument();
+    expect(getSpy).toHaveBeenCalledWith("/messages");
+    expect(getSpy).toHaveBeenCalledWith("/tasks/task-1/comments");
+  });
+
+  it("sends a new comment and clears the composer", async () => {
+    const now = new Date("2024-05-01T10:00:00.000Z").toISOString();
+    const messageResponse = [
+      {
+        id: "msg-1",
+        task: { id: "task-1", title: "Ventiliacija", hiveId: "hive-1", hiveName: "A1" },
+        author: {
+          id: "user-2",
+          email: "ieva@example.com",
+          roles: ["keeper"],
+          firstName: "Ieva",
+          lastName: "Medune",
+          displayName: ""
+        },
+        content: "Patikrinkite ventiliaciją asap",
+        createdAt: now,
+        isOwn: false
+      }
+    ];
+    const initialComments = [
+      {
+        id: "comment-1",
+        content: "Atliksiu šį darbą rytoj ryte.",
+        author: {
+          id: "user-3",
+          email: "jonas@example.com",
+          roles: ["keeper"]
+        },
+        createdAt: now
+      }
+    ];
+    const createdComment = {
+      id: "comment-2",
+      content: "Patikrinau – viskas veikia.",
+      author: {
+        id: "user-1",
+        email: "aš@example.com",
+        roles: ["keeper"]
+      },
+      createdAt: new Date("2024-05-01T12:00:00.000Z").toISOString()
+    };
+
+    let commentCalls = 0;
+    vi.spyOn(apiClient, "get").mockImplementation(async (path: string) => {
+      if (path === "/messages") {
+        return messageResponse as unknown as Promise<unknown>;
+      }
+      if (path === "/tasks/task-1/comments") {
+        commentCalls += 1;
+        if (commentCalls === 1) {
+          return initialComments as unknown as Promise<unknown>;
+        }
+        return [...initialComments, createdComment] as unknown as Promise<unknown>;
+      }
+      throw new Error(`Unexpected path: ${path}`);
+    });
+
+    const postSpy = vi.spyOn(apiClient, "post").mockResolvedValue(createdComment);
+
+    renderWithClient(<MessagingPage />);
+    const user = userEvent.setup();
+
+    await waitFor(() => expect(screen.getByText("Atliksiu šį darbą rytoj ryte.")).toBeInTheDocument());
+
+    const textarea = await screen.findByLabelText("Nauja žinutė");
+    await user.type(textarea, "Patikrinau – viskas veikia.");
+    await user.click(screen.getByRole("button", { name: "Siųsti" }));
+
+    await waitFor(() =>
+      expect(postSpy).toHaveBeenCalledWith("/tasks/task-1/comments", { content: "Patikrinau – viskas veikia." })
+    );
+    await waitFor(() => expect(screen.getByText("Patikrinau – viskas veikia.")).toBeInTheDocument());
+    expect((textarea as HTMLTextAreaElement).value).toBe("");
+  });
+
+  it("surfaces validation errors from the messaging service", async () => {
+    const now = new Date().toISOString();
+    const messageResponse = [
+      {
+        id: "msg-1",
+        task: { id: "task-1", title: "Ventiliacija", hiveId: "hive-1", hiveName: "A1" },
+        author: {
+          id: "user-2",
+          email: "ieva@example.com",
+          roles: ["keeper"],
+          firstName: "Ieva",
+          lastName: "Medune",
+          displayName: ""
+        },
+        content: "Patikrinkite ventiliaciją asap",
+        createdAt: now,
+        isOwn: false
+      }
+    ];
+    const commentsResponse = [
+      {
+        id: "comment-1",
+        content: "Atliksiu šį darbą rytoj ryte.",
+        author: {
+          id: "user-3",
+          email: "jonas@example.com",
+          roles: ["keeper"]
+        },
+        createdAt: now
+      }
+    ];
+
+    vi.spyOn(apiClient, "get").mockImplementation(async (path: string) => {
+      if (path === "/messages") {
+        return messageResponse as unknown as Promise<unknown>;
+      }
+      if (path === "/tasks/task-1/comments") {
+        return commentsResponse as unknown as Promise<unknown>;
+      }
+      throw new Error(`Unexpected path: ${path}`);
+    });
+
+    const postError = new ApiClientError("Žinutė per ilga", 400, null);
+    vi.spyOn(apiClient, "post").mockRejectedValue(postError);
+
+    renderWithClient(<MessagingPage />);
+    const user = userEvent.setup();
+
+    await waitFor(() => expect(screen.getByText("Atliksiu šį darbą rytoj ryte.")).toBeInTheDocument());
+
+    const textarea = await screen.findByLabelText("Nauja žinutė");
+    await user.type(textarea, "{selectall}{backspace}Labai ilga žinutė kuri viršija ribą");
+    await user.click(screen.getByRole("button", { name: "Siųsti" }));
+
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("Žinutė per ilga"));
+    expect((textarea as HTMLTextAreaElement).value).toBe("Labai ilga žinutė kuri viršija ribą");
   });
 });

--- a/apps/web/src/features/messaging/hooks.test.tsx
+++ b/apps/web/src/features/messaging/hooks.test.tsx
@@ -1,0 +1,98 @@
+import type { ReactNode } from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiClientError, apiClient } from "../../lib/apiClient";
+import { mapCommentResponse, ThreadComment, useCommentComposer } from "./hooks";
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false
+      }
+    }
+  });
+
+describe("useCommentComposer", () => {
+  let client: QueryClient;
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    client = createQueryClient();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    client.clear();
+  });
+
+  it("adds an optimistic entry and replaces it with the saved comment", async () => {
+    const initial = [
+      mapCommentResponse({
+        id: "comment-1",
+        content: "Patikrinsiu vakare.",
+        author: { id: "user-2", email: "ieva@example.com", roles: ["keeper"] },
+        createdAt: "2024-05-01T08:00:00.000Z"
+      })
+    ];
+    const createdAt = "2024-05-01T09:30:00.000Z";
+    const apiResponse = {
+      id: "comment-2",
+      content: "Jau atlikta.",
+      author: { id: "user-1", email: "aš@example.com", roles: ["keeper"] },
+      createdAt
+    };
+    vi.spyOn(apiClient, "post").mockResolvedValue(apiResponse);
+
+    client.setQueryData<ThreadComment[]>(["task-comments", "task-1"], initial);
+
+    const { result } = renderHook(() => useCommentComposer("task-1"), { wrapper });
+
+    await act(async () => {
+      const promise = result.current.submit("Jau atlikta.");
+      const optimistic = client.getQueryData<ThreadComment[]>(["task-comments", "task-1"]);
+      expect(optimistic).toHaveLength(2);
+      expect(optimistic?.[1].isOptimistic).toBe(true);
+      await promise;
+    });
+
+    await waitFor(() => {
+      const comments = client.getQueryData<ThreadComment[]>(["task-comments", "task-1"]);
+      expect(comments).toHaveLength(2);
+      expect(comments?.[1]).toMatchObject({
+        id: "comment-2",
+        content: "Jau atlikta.",
+        authorLabel: "aš@example.com"
+      });
+      expect(comments?.[1].isOptimistic).toBeUndefined();
+    });
+  });
+
+  it("rolls back optimistic updates and exposes validation errors", async () => {
+    const initial = [
+      mapCommentResponse({
+        id: "comment-1",
+        content: "Patikrinsiu vakare.",
+        author: { id: "user-2", email: "ieva@example.com", roles: ["keeper"] },
+        createdAt: "2024-05-01T08:00:00.000Z"
+      })
+    ];
+    client.setQueryData<ThreadComment[]>(["task-comments", "task-1"], initial);
+
+    const error = new ApiClientError("Žinutė per trumpa", 400, null);
+    vi.spyOn(apiClient, "post").mockRejectedValue(error);
+
+    const { result } = renderHook(() => useCommentComposer("task-1"), { wrapper });
+
+    await expect(result.current.submit("J"))
+      .rejects.toThrowError();
+
+    await waitFor(() => expect(result.current.error).toBe("Žinutė per trumpa"));
+    const comments = client.getQueryData<ThreadComment[]>(["task-comments", "task-1"]);
+    expect(comments).toEqual(initial);
+  });
+});

--- a/apps/web/src/features/messaging/hooks.ts
+++ b/apps/web/src/features/messaging/hooks.ts
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ApiClientError, apiClient } from "../../lib/apiClient";
+import { formatSentAt } from "./utils";
+
+export type CommentApiItem = {
+  id: string;
+  content: string;
+  author: {
+    id: string;
+    email: string;
+    roles: string[];
+  };
+  createdAt: string;
+};
+
+export type ThreadComment = {
+  id: string;
+  content: string;
+  createdAt: string;
+  formattedCreatedAt: string;
+  authorLabel: string;
+  isOptimistic?: boolean;
+};
+
+export const mapCommentResponse = (item: CommentApiItem): ThreadComment => ({
+  id: item.id,
+  content: item.content,
+  createdAt: item.createdAt,
+  formattedCreatedAt: formatSentAt(item.createdAt),
+  authorLabel: item.author.email
+});
+
+export const useTaskComments = (taskId: string | null) =>
+  useQuery<CommentApiItem[], ApiClientError, ThreadComment[]>({
+    queryKey: ["task-comments", taskId],
+    queryFn: () => apiClient.get<CommentApiItem[]>(`/tasks/${taskId}/comments`),
+    enabled: Boolean(taskId),
+    select: (items) => items.map(mapCommentResponse),
+    staleTime: 10_000
+  });
+
+type ComposerContext = {
+  previousComments?: ThreadComment[];
+};
+
+export const useCommentComposer = (taskId: string | null) => {
+  const queryClient = useQueryClient();
+  const [error, setError] = useState<string | null>(null);
+  const queryKey = useMemo(() => (taskId ? (["task-comments", taskId] as const) : null), [taskId]);
+
+  useEffect(() => {
+    setError(null);
+  }, [taskId]);
+
+  const mutation = useMutation<CommentApiItem, ApiClientError, string, ComposerContext>({
+    mutationFn: async (content: string) => {
+      if (!taskId) {
+        throw new Error("Nepasirinkta užduotis.");
+      }
+      return apiClient.post<CommentApiItem>(`/tasks/${taskId}/comments`, { content });
+    },
+    onMutate: async (content) => {
+      if (!queryKey) {
+        return {};
+      }
+      setError(null);
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<ThreadComment[]>(queryKey) ?? [];
+      const timestamp = new Date().toISOString();
+      const optimistic: ThreadComment = {
+        id: `optimistic-${Date.now()}`,
+        content,
+        createdAt: timestamp,
+        formattedCreatedAt: formatSentAt(timestamp),
+        authorLabel: "Jūs",
+        isOptimistic: true
+      };
+      queryClient.setQueryData<ThreadComment[]>(queryKey, [...previous, optimistic]);
+      return { previousComments: previous };
+    },
+    onError: (err, _variables, context) => {
+      if (queryKey && context?.previousComments) {
+        queryClient.setQueryData<ThreadComment[]>(queryKey, context.previousComments);
+      }
+      const fallback = "Nepavyko išsiųsti žinutės. Pabandykite dar kartą.";
+      if (err instanceof ApiClientError) {
+        setError(err.message || fallback);
+      } else {
+        setError(fallback);
+      }
+    },
+    onSuccess: (comment) => {
+      if (!queryKey) {
+        return;
+      }
+      setError(null);
+      queryClient.setQueryData<ThreadComment[]>(queryKey, (current = []) => {
+        const stable = current.filter((item) => !item.isOptimistic);
+        return [...stable, mapCommentResponse(comment)];
+      });
+    },
+    onSettled: () => {
+      if (queryKey) {
+        queryClient.invalidateQueries({ queryKey });
+      }
+    }
+  });
+
+  const submit = useCallback(
+    (content: string) => mutation.mutateAsync(content),
+    [mutation]
+  );
+
+  const resetError = useCallback(() => setError(null), []);
+
+  return {
+    submit,
+    isSubmitting: mutation.isPending,
+    error,
+    resetError
+  };
+};

--- a/apps/web/src/features/messaging/utils.ts
+++ b/apps/web/src/features/messaging/utils.ts
@@ -1,0 +1,47 @@
+export type MessageAuthorLike = {
+  email: string;
+  firstName?: string | null;
+  lastName?: string | null;
+  displayName?: string | null;
+};
+
+export const formatSender = (author: MessageAuthorLike): string => {
+  if (author.displayName && author.displayName.trim()) {
+    return author.displayName;
+  }
+  const parts = [author.firstName, author.lastName].filter((part) => part && String(part).trim());
+  if (parts.length) {
+    return parts.join(" ");
+  }
+  return author.email;
+};
+
+export const formatPreview = (content: string): string => {
+  const normalized = content.trim();
+  return normalized.length > 120 ? `${normalized.slice(0, 117)}...` : normalized;
+};
+
+export const formatSentAt = (value: string): string => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "Nežinomas laikas";
+  }
+  return new Intl.DateTimeFormat("lt-LT", { dateStyle: "medium", timeStyle: "short" }).format(date);
+};
+
+export type UnreadComputable = {
+  isOwn: boolean;
+  createdAt: string;
+};
+
+export const computeUnread = (item: UnreadComputable): boolean => {
+  if (item.isOwn) {
+    return false;
+  }
+  const created = new Date(item.createdAt);
+  if (Number.isNaN(created.getTime())) {
+    return false;
+  }
+  const now = Date.now();
+  return now - created.getTime() < 48 * 60 * 60 * 1000;
+};

--- a/src/messaging/__tests__/messaging.service.spec.ts
+++ b/src/messaging/__tests__/messaging.service.spec.ts
@@ -1,0 +1,97 @@
+import { ForbiddenException } from '@nestjs/common';
+import { DataSource, EntityManager } from 'typeorm';
+import { MessagingService } from '../messaging.service';
+import { CommentsRepository } from '../comments.repository';
+import { TasksRepository } from '../../tasks/tasks.repository';
+import { UsersService } from '../../users/users.service';
+import { NotificationsService } from '../../notifications/notifications.service';
+import { AuthenticatedUser } from '../../auth/decorators/current-user.decorator';
+import { Task } from '../../tasks/task.entity';
+import { Hive } from '../../hives/hive.entity';
+import { User } from '../../users/user.entity';
+
+const createUser = (id: string): User => ({
+  id
+} as User);
+
+describe('MessagingService - addComment', () => {
+  let service: MessagingService;
+  let commentsRepository: jest.Mocked<CommentsRepository>;
+  let tasksRepository: jest.Mocked<TasksRepository>;
+  let usersService: jest.Mocked<UsersService>;
+  let notificationsService: jest.Mocked<NotificationsService>;
+  let dataSource: { transaction: jest.Mock };
+
+  beforeEach(() => {
+    commentsRepository = {
+      create: jest.fn(),
+      save: jest.fn(),
+      findByTask: jest.fn(),
+      findRecentForAccessibleTasks: jest.fn()
+    } as unknown as jest.Mocked<CommentsRepository>;
+
+    tasksRepository = {
+      create: jest.fn(),
+      save: jest.fn(),
+      findById: jest.fn(),
+      remove: jest.fn(),
+      findByHive: jest.fn(),
+      findAllWithRelations: jest.fn(),
+      findAccessible: jest.fn()
+    } as unknown as jest.Mocked<TasksRepository>;
+
+    usersService = {
+      findByIdOrFail: jest.fn()
+    } as unknown as jest.Mocked<UsersService>;
+
+    notificationsService = {
+      notifyUsers: jest.fn()
+    } as unknown as jest.Mocked<NotificationsService>;
+
+    dataSource = {
+      transaction: jest.fn()
+    };
+
+    service = new MessagingService(
+      commentsRepository,
+      tasksRepository,
+      usersService,
+      notificationsService,
+      dataSource as unknown as DataSource
+    );
+  });
+
+  it('throws when a user outside the hive attempts to comment', async () => {
+    const hive: Hive = {
+      id: 'hive-1',
+      name: 'Test Hive',
+      owner: createUser('owner-1'),
+      members: [createUser('member-1')]
+    } as Hive;
+
+    const task: Task = {
+      id: 'task-1',
+      title: 'Inspect ventilation',
+      hive,
+      assignedTo: null
+    } as Task;
+
+    const manager = {} as EntityManager;
+    (tasksRepository.findById as jest.Mock).mockResolvedValue(task);
+    dataSource.transaction.mockImplementation(async (run) => run(manager));
+
+    const user: AuthenticatedUser = {
+      userId: 'intruder-1',
+      email: 'intruder@example.com',
+      roles: []
+    };
+
+    await expect(service.addComment(user, 'task-1', { content: 'Sveiki' }))
+      .rejects.toBeInstanceOf(ForbiddenException);
+
+    expect(tasksRepository.findById).toHaveBeenCalledWith('task-1', manager);
+    expect(usersService.findByIdOrFail).not.toHaveBeenCalled();
+    expect(commentsRepository.save).not.toHaveBeenCalled();
+    expect(notificationsService.notifyUsers).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- fetch task-specific comment threads on the messaging page and render the conversation timeline with task and hive context
- add a comment composer with optimistic React Query updates, validation feedback, and supporting utilities/hooks
- cover the new hooks and UI interactions with Vitest tests and add a backend guard test for unauthorized comment attempts

## Testing
- `npm test`
- `npm --prefix apps/web run test` *(fails: jsdom dependency cannot be installed in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2893c11f88333a2a60accaf80caae