### PR TITLE
feat: enhance notifications and push subscription flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,5 @@ Email and push notifications are now sent through SendGrid and Firebase Cloud Me
 | `FIREBASE_PRIVATE_KEY` | Service account private key (literal `\n` escapes are converted to newlines). |
 
 Client devices register push tokens by calling `POST /notifications/subscriptions`, and tokens can be revoked with `DELETE /notifications/subscriptions/:id`. Each domain module now passes channel hints so that the `NotificationsService` fans out in-app, email, and push payloads while recording delivery status metadata on the notification records.
+
+Front-end integracijos pavyzdžiai bei naršyklės konfigūracijos žingsniai aprašyti faile [`docs/browser-push.md`](docs/browser-push.md).

--- a/apps/web/src/features/dashboard/DashboardPage.tsx
+++ b/apps/web/src/features/dashboard/DashboardPage.tsx
@@ -103,7 +103,9 @@ const mapAlert = (alert: DashboardApiAlert): Notification => {
     title: alert.title,
     description: alert.description,
     type,
-    createdAt: alert.createdAt
+    createdAt: alert.createdAt,
+    readAt: null,
+    isRead: false
   };
 };
 

--- a/apps/web/src/features/notifications/NotificationsPage.test.tsx
+++ b/apps/web/src/features/notifications/NotificationsPage.test.tsx
@@ -1,0 +1,125 @@
+import type { ReactElement } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import NotificationsPage from "./NotificationsPage";
+import type { NotificationResponse } from "../../types";
+import { apiClient } from "../../lib/apiClient";
+
+type TestQueryClient = QueryClient & { invalidateQueries: QueryClient["invalidateQueries"] };
+
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false
+      }
+    }
+  });
+
+let testQueryClient: TestQueryClient | null = null;
+
+const renderWithClient = (ui: ReactElement) => {
+  const client = createTestQueryClient() as TestQueryClient;
+  testQueryClient = client;
+
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+};
+
+describe("NotificationsPage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    testQueryClient?.clear();
+    testQueryClient = null;
+  });
+
+  it("marks notifications as read and invalidates the list", async () => {
+    const user = userEvent.setup();
+    const notifications: NotificationResponse[] = [
+      {
+        id: "n-42",
+        title: "Avilio temperatūra",
+        body: "Viršijo kritinę ribą",
+        channel: "IN_APP",
+        status: "PENDING",
+        metadata: { severity: "warning" },
+        relatedTaskId: null,
+        relatedInspectionId: null,
+        relatedHarvestId: null,
+        auditEventId: null,
+        sentAt: null,
+        readAt: null,
+        createdAt: "2024-07-01T08:00:00.000Z",
+        updatedAt: "2024-07-01T08:00:00.000Z",
+        deliveryMetadata: null
+      }
+    ];
+
+    const readResponse: NotificationResponse = {
+      ...notifications[0],
+      status: "READ",
+      readAt: "2024-07-01T08:10:00.000Z"
+    };
+
+    vi.spyOn(apiClient, "get").mockResolvedValue(notifications);
+    const patchSpy = vi.spyOn(apiClient, "patch").mockResolvedValue(readResponse);
+
+    renderWithClient(<NotificationsPage />);
+
+    await waitFor(() => expect(screen.getByText("Avilio temperatūra")).toBeInTheDocument());
+
+    const invalidateSpy = vi.spyOn(testQueryClient!, "invalidateQueries");
+    const markButton = screen.getByRole("button", { name: /Pažymėti kaip skaitytą/i });
+
+    await user.click(markButton);
+
+    await waitFor(() =>
+      expect(patchSpy).toHaveBeenCalledWith(`/notifications/${notifications[0].id}/read`)
+    );
+
+    await waitFor(() => expect(screen.getAllByText(/Perskaityta/i).length).toBeGreaterThan(0));
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: /Pažymėti kaip skaitytą/i })).not.toBeInTheDocument()
+    );
+    await waitFor(() =>
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["notifications"] })
+    );
+  });
+
+  it("surfaces an inline error when marking as read fails", async () => {
+    const user = userEvent.setup();
+    const notifications: NotificationResponse[] = [
+      {
+        id: "n-77",
+        title: "Avilio svoris",
+        body: "Staigus pokytis",
+        channel: "IN_APP",
+        status: "PENDING",
+        metadata: { severity: "warning" },
+        relatedTaskId: null,
+        relatedInspectionId: null,
+        relatedHarvestId: null,
+        auditEventId: null,
+        sentAt: null,
+        readAt: null,
+        createdAt: "2024-07-02T11:00:00.000Z",
+        updatedAt: "2024-07-02T11:00:00.000Z",
+        deliveryMetadata: null
+      }
+    ];
+
+    vi.spyOn(apiClient, "get").mockResolvedValue(notifications);
+    vi.spyOn(apiClient, "patch").mockRejectedValue(new Error("Serveris nepasiekiamas"));
+
+    renderWithClient(<NotificationsPage />);
+
+    await waitFor(() => expect(screen.getByText("Avilio svoris")).toBeInTheDocument());
+
+    const markButton = screen.getByRole("button", { name: /Pažymėti kaip skaitytą/i });
+    await user.click(markButton);
+
+    await waitFor(() => expect(screen.getByText("Serveris nepasiekiamas")).toBeInTheDocument());
+    await waitFor(() => expect(markButton).toBeEnabled());
+  });
+});

--- a/apps/web/src/features/notifications/notificationMapper.test.ts
+++ b/apps/web/src/features/notifications/notificationMapper.test.ts
@@ -66,6 +66,8 @@ describe("mapNotificationResponse", () => {
     expect(result.title).toBe("Padidėjusi drėgmė");
     expect(result.description).toBe("Viršijo ribą");
     expect(result.type).toBe("įspėjimas");
+    expect(result.readAt).toBeNull();
+    expect(result.isRead).toBe(false);
     expect(result.createdAt).toBe(
       new Intl.DateTimeFormat("lt-LT", {
         dateStyle: "medium",
@@ -91,5 +93,25 @@ describe("mapNotificationResponse", () => {
     expect(result.description).toBe("Nėra papildomos informacijos.");
     expect(result.type).toBe("informacija");
     expect(result.createdAt).toBe("invalid");
+    expect(result.readAt).toBeNull();
+    expect(result.isRead).toBe(false);
+  });
+
+  it("marks notifications as read when readAt is present", () => {
+    const payload: NotificationResponse = {
+      ...base,
+      id: "n-3",
+      readAt: "2024-07-02T09:15:00.000Z"
+    };
+
+    const result = mapNotificationResponse(payload);
+    expect(result.isRead).toBe(true);
+    expect(result.readAt).toBe(
+      new Intl.DateTimeFormat("lt-LT", {
+        dateStyle: "medium",
+        timeStyle: "short",
+        timeZone: "Europe/Vilnius"
+      }).format(new Date(payload.readAt!))
+    );
   });
 });

--- a/apps/web/src/features/notifications/notificationMapper.ts
+++ b/apps/web/src/features/notifications/notificationMapper.ts
@@ -72,13 +72,16 @@ export const formatNotificationTimestamp = (value: string | Date | null | undefi
 export const mapNotificationResponse = (payload: NotificationResponse): Notification => {
   const title = payload.title.trim() || DEFAULT_NOTIFICATION_TITLE;
   const description = payload.body.trim() || DEFAULT_NOTIFICATION_DESCRIPTION;
+  const readAt = payload.readAt ? formatNotificationTimestamp(payload.readAt) : null;
 
   return {
     id: payload.id,
     title,
     description,
     type: mapNotificationSeverity(payload.metadata ?? null, payload.status),
-    createdAt: formatNotificationTimestamp(payload.createdAt)
+    createdAt: formatNotificationTimestamp(payload.createdAt),
+    readAt,
+    isRead: Boolean(readAt)
   };
 };
 

--- a/apps/web/src/features/notifications/usePushSubscription.ts
+++ b/apps/web/src/features/notifications/usePushSubscription.ts
@@ -1,0 +1,170 @@
+import { useCallback, useMemo, useState } from "react";
+import { apiClient } from "../../lib/apiClient";
+
+type PermissionState = NotificationPermission | "unsupported";
+
+type RegisterOptions = {
+  token?: string | null;
+  getToken?: () => Promise<string | null>;
+  metadata?: Record<string, unknown>;
+};
+
+type UsePushSubscriptionResult = {
+  token: string | null;
+  status: "idle" | "pending" | "success" | "error";
+  error: string | null;
+  permission: PermissionState;
+  isSupported: boolean;
+  isRegistered: boolean;
+  register: (options?: RegisterOptions) => Promise<string>;
+  revoke: (tokenOverride?: string | null) => Promise<void>;
+};
+
+const resolvePermission = async (
+  request: () => NotificationPermission | Promise<NotificationPermission>
+): Promise<NotificationPermission> => {
+  const result = request();
+  if (result instanceof Promise) {
+    return result;
+  }
+
+  return Promise.resolve(result);
+};
+
+const initialPermission: PermissionState =
+  typeof window !== "undefined" && typeof window.Notification !== "undefined"
+    ? window.Notification.permission
+    : "unsupported";
+
+export const usePushSubscription = (): UsePushSubscriptionResult => {
+  const [token, setToken] = useState<string | null>(null);
+  const [status, setStatus] = useState<"idle" | "pending" | "success" | "error">("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [permission, setPermission] = useState<PermissionState>(initialPermission);
+
+  const ensurePermission = useCallback(async (): Promise<PermissionState> => {
+    if (typeof window === "undefined" || typeof window.Notification === "undefined") {
+      setPermission("unsupported");
+      return "unsupported";
+    }
+
+    const current = window.Notification.permission;
+
+    if (current === "granted" || current === "denied") {
+      setPermission(current);
+      return current;
+    }
+
+    if (typeof window.Notification.requestPermission === "function") {
+      try {
+        const result = await resolvePermission(() => window.Notification.requestPermission());
+        setPermission(result);
+        return result;
+      } catch (requestError) {
+        setPermission("denied");
+        throw requestError instanceof Error
+          ? requestError
+          : new Error("Nepavyko gauti naršyklės leidimo pranešimams.");
+      }
+    }
+
+    setPermission(current);
+    return current;
+  }, []);
+
+  const register = useCallback<UsePushSubscriptionResult["register"]>(
+    async (options) => {
+      setStatus("pending");
+      setError(null);
+
+      try {
+        const permissionResult = await ensurePermission();
+
+        if (permissionResult === "denied") {
+          throw new Error("Naršyklė neleido rodyti pranešimų.");
+        }
+
+        let resolvedToken = options?.token ?? null;
+
+        if (!resolvedToken && options?.getToken) {
+          resolvedToken = await options.getToken();
+        }
+
+        if (!resolvedToken) {
+          throw new Error("Nepavyko gauti pranešimų rakto.");
+        }
+
+        await apiClient.post("/notifications/subscriptions", {
+          token: resolvedToken,
+          metadata: {
+            platform: "web",
+            permission: permissionResult,
+            ...options?.metadata
+          }
+        });
+
+        setToken(resolvedToken);
+        setStatus("success");
+        return resolvedToken;
+      } catch (registrationError) {
+        const message =
+          registrationError instanceof Error
+            ? registrationError.message
+            : "Nepavyko išsaugoti pranešimų prenumeratos.";
+        setError(message);
+        setStatus("error");
+        throw registrationError instanceof Error
+          ? registrationError
+          : new Error(message);
+      }
+    },
+    [ensurePermission]
+  );
+
+  const revoke = useCallback<UsePushSubscriptionResult["revoke"]>(
+    async (tokenOverride) => {
+      const activeToken = tokenOverride ?? token;
+
+      if (!activeToken) {
+        const message = "Nėra prenumeratos rakto, kurį būtų galima atšaukti.";
+        setError(message);
+        setStatus("error");
+        throw new Error(message);
+      }
+
+      setStatus("pending");
+      setError(null);
+
+      try {
+        await apiClient.delete(`/notifications/subscriptions/${encodeURIComponent(activeToken)}`);
+        setToken(null);
+        setStatus("idle");
+      } catch (revokeError) {
+        const message =
+          revokeError instanceof Error
+            ? revokeError.message
+            : "Nepavyko atšaukti pranešimų prenumeratos.";
+        setError(message);
+        setStatus("error");
+        throw revokeError instanceof Error ? revokeError : new Error(message);
+      }
+    },
+    [token]
+  );
+
+  return useMemo(
+    () => ({
+      token,
+      status,
+      error,
+      permission,
+      isSupported: permission !== "unsupported",
+      isRegistered: Boolean(token),
+      register,
+      revoke
+    }),
+    [error, permission, register, revoke, status, token]
+  );
+};
+
+export default usePushSubscription;

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -60,6 +60,8 @@ export type Notification = {
   description: string;
   type: "įspėjimas" | "informacija" | "kritinis";
   createdAt: string;
+  readAt: string | null;
+  isRead: boolean;
 };
 
 export type NotificationDeliveryDetail = {

--- a/docs/browser-push.md
+++ b/docs/browser-push.md
@@ -1,0 +1,90 @@
+# Naršyklės stumdomi pranešimai
+
+Žiniatinklio konsolė naudoja `usePushSubscription` kabliuką (`apps/web/src/features/notifications/usePushSubscription.ts`) naršyklės pranešimų prenumeratoms registruoti. Kabliukas iškviečia `POST /notifications/subscriptions`, perduoda naršyklės/Firebase sugeneruotą žetoną ir leidžia atšaukti prenumeratą per `DELETE /notifications/subscriptions/:token`. Toliau pateikiami žingsniai, kaip sukonfigūruoti aplinką ir integruoti kabliuką su Firebase Cloud Messaging (FCM) arba kitu Web Push tiekėju.
+
+## Paruošimas
+
+1. **Firebase projektas.** Sukurkite arba pasirinkite esamą projektą Firebase konsolėje ir įjunkite Cloud Messaging modulį. Sukurkite Web programėlę, atsisiųskite `firebaseConfig` reikšmes ir sugeneruokite VAPID viešąjį raktą (Settings → Cloud Messaging → Web configuration).
+2. **Service worker.** Į projektą įtraukite FCM service worker failą, pvz. `firebase-messaging-sw.js`, kuriame inicializuojamas `firebase/app` ir `firebase/messaging`. Vite distribucijai tokį failą patalpinkite `apps/web/public` kataloge, kad būtų pasiekiamas per `/firebase-messaging-sw.js`.
+3. **Aplinkos kintamieji.** Pridėkite `VITE_FIREBASE_` reikšmes prie `apps/web/.env` (arba `.env.local`) failo ir pasirūpinkite, kad `VITE_API_BASE_URL` rodytų į NestJS API adresą, kuris priima prenumeratos užklausas.
+4. **Service worker registracija.** Kliento aplikacijoje (pvz., `main.tsx`) užregistruokite service workerą:
+
+   ```ts
+   if ("serviceWorker" in navigator) {
+     navigator.serviceWorker.register("/firebase-messaging-sw.js");
+   }
+   ```
+
+## Žetono gavimas su Firebase
+
+`usePushSubscription` kabliukas sąmoningai neimportuoja Firebase bibliotekų, todėl galima naudoti tiek FCM, tiek kitus Web Push tiekėjus. Toliau pateiktas pavyzdys parodo, kaip apgaubti `getToken` funkciją iš `firebase/messaging` ir perduoti ją kabliukui:
+
+```ts
+import { useEffect } from "react";
+import { getMessaging, getToken } from "firebase/messaging";
+import { initializeApp } from "firebase/app";
+import usePushSubscription from "../features/notifications/usePushSubscription";
+
+const firebaseApp = initializeApp({
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  appId: import.meta.env.VITE_FIREBASE_APP_ID
+});
+
+const messaging = getMessaging(firebaseApp);
+
+export const BrowserPushSetup = () => {
+  const { register, revoke, status, error, isRegistered } = usePushSubscription();
+
+  useEffect(() => {
+    const enablePush = async () => {
+      await register({
+        getToken: async () =>
+          getToken(messaging, {
+            vapidKey: import.meta.env.VITE_FIREBASE_VAPID_KEY,
+            serviceWorkerRegistration: await navigator.serviceWorker.ready
+          }),
+        metadata: {
+          sdk: "firebase",
+          locale: navigator.language
+        }
+      });
+    };
+
+    enablePush().catch((reason) => {
+      console.error("Nepavyko aktyvuoti pranešimų", reason);
+    });
+
+    return () => {
+      if (!isRegistered) {
+        return;
+      }
+
+      revoke().catch((reason) => {
+        console.error("Nepavyko atšaukti prenumeratos", reason);
+      });
+    };
+  }, [isRegistered, register, revoke]);
+
+  return (
+    <div>
+      <p>Būsenos kodas: {status}</p>
+      {error ? <p role="alert">{error}</p> : null}
+    </div>
+  );
+};
+```
+
+Kabliukas pats pasirūpina `Notification.requestPermission()` kvietimu (jei API pasiekiama) ir automatiškai pažymi prenumeraciją kaip `success`, kai backendas patvirtina žetoną. Jei naršyklė nesupranta `Notification` API (pvz., senesnėse iOS versijose), `permission` bus `"unsupported"`, tačiau registracija vis tiek vyks tol, kol pateikiamas žetonas.
+
+## Prenumeratos atšaukimas
+
+Kai vartotojas atsijungia arba išjungia pranešimus, kvieskite `revoke()` kabliuko metodą. Pagal nutylėjimą jis panaudos paskutinį sėkmingai išsaugotą žetoną, tačiau galima perduoti ir konkrečią reikšmę: `revoke(customToken)`. Funkcija iškvies `DELETE /notifications/subscriptions/:token` ir išvalys lokalią būseną.
+
+## Derinimas
+
+- Įsitikinkite, kad backend API atsako su `201` arba `204` į `POST /notifications/subscriptions` ir grąžina `204` į `DELETE` užklausas.
+- Naršyklėje patikrinkite `Application → Service Workers`, ar service worker aktyvus, ir `Application → Push Messaging`, ar prenumerata užregistruota.
+- Jei `status` pereina į `error`, peržiūrėkite `error` tekstą (kabliukas persiunčia API klaidų žinutes) bei `console` logus, kad nustatytumėte priežastį.


### PR DESCRIPTION
## Summary
- add mark-as-read controls to the notifications page with optimistic updates and query invalidation
- implement a reusable push subscription hook/service and document the browser setup
- cover the new behaviours with mapper and page tests that mock the API client

## Testing
- npm --prefix apps/web run test *(fails: missing jsdom dependency in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d289401d0883339bfb6b872837d860