### PR TITLE
Add accessible mobile navigation drawer

### DIFF
--- a/apps/web/src/components/layout/AppLayout.test.tsx
+++ b/apps/web/src/components/layout/AppLayout.test.tsx
@@ -1,0 +1,67 @@
+import { ContextType, ReactElement, ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { AppLayout } from "./AppLayout";
+import { AuthContext } from "../../providers/AuthProvider";
+
+type WrapperProps = {
+  children: ReactNode;
+};
+
+type AuthValue = NonNullable<ContextType<typeof AuthContext>>;
+
+const createAuthValue = (): AuthValue => ({
+  status: "authenticated",
+  user: { id: "1", email: "user@example.com", name: "Test User" },
+  error: null,
+  isAuthenticated: true,
+  isProcessing: false,
+  accessToken: "token",
+  login: vi.fn().mockResolvedValue(undefined),
+  logout: vi.fn().mockResolvedValue(undefined),
+  refresh: vi.fn().mockResolvedValue(undefined)
+});
+
+const renderWithProviders = (ui: ReactElement) => {
+  const authValue = createAuthValue();
+
+  const Wrapper = ({ children }: WrapperProps) => (
+    <MemoryRouter initialEntries={["/"]}>
+      <AuthContext.Provider value={authValue}>{children}</AuthContext.Provider>
+    </MemoryRouter>
+  );
+
+  return render(ui, { wrapper: Wrapper });
+};
+
+describe("AppLayout", () => {
+  it("toggles the mobile navigation drawer", async () => {
+    renderWithProviders(
+      <AppLayout>
+        <p>Turinys</p>
+      </AppLayout>
+    );
+
+    const toggle = screen.getByRole("button", { name: /perjungti navigaciją/i });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    const user = userEvent.setup();
+    await user.click(toggle);
+
+    const dialog = await screen.findByRole("dialog", { name: /navigacija/i });
+    expect(dialog).toBeInTheDocument();
+
+    const routes = within(dialog).getByRole("link", { name: "Valdymo suvestinė" });
+    expect(routes).toBeInTheDocument();
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+    const closeButton = within(dialog).getByRole("button", { name: /uždaryti meniu/i });
+    await user.click(closeButton);
+
+    expect(screen.queryByRole("dialog", { name: /navigacija/i })).not.toBeInTheDocument();
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+  });
+});

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -1,17 +1,35 @@
-import { ReactNode } from "react";
+import { ReactNode, useState } from "react";
 import { Sidebar } from "./Sidebar";
 import { TopBar } from "./TopBar";
+import { MobileNav } from "./MobileNav";
+
+const MOBILE_NAV_ID = "mobile-navigation";
 
 export const AppLayout = ({ children }: { children: ReactNode }) => {
+  const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
+
+  const handleToggleMobileNav = () => {
+    setIsMobileNavOpen((previous) => !previous);
+  };
+
+  const handleCloseMobileNav = () => {
+    setIsMobileNavOpen(false);
+  };
+
   return (
     <div className="flex min-h-screen bg-slate-950 text-slate-100">
       <Sidebar />
       <div className="flex flex-1 flex-col">
-        <TopBar />
+        <TopBar
+          isMobileNavOpen={isMobileNavOpen}
+          onToggleMobileNav={handleToggleMobileNav}
+          mobileNavId={MOBILE_NAV_ID}
+        />
         <main className="flex-1 overflow-y-auto bg-slate-950 p-6 lg:p-10">
           <div className="mx-auto max-w-7xl space-y-8">{children}</div>
         </main>
       </div>
+      <MobileNav isOpen={isMobileNavOpen} onClose={handleCloseMobileNav} menuId={MOBILE_NAV_ID} />
     </div>
   );
 };

--- a/apps/web/src/components/layout/MobileNav.tsx
+++ b/apps/web/src/components/layout/MobileNav.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useRef } from "react";
+import { XMarkIcon } from "@heroicons/react/24/outline";
+
+import { SidebarContent } from "./Sidebar";
+
+const FOCUSABLE_SELECTORS = [
+  "a[href]",
+  "button:not([disabled])",
+  "textarea:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])"
+].join(", ");
+
+type MobileNavProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  menuId: string;
+};
+
+export const MobileNav = ({ isOpen, onClose, menuId }: MobileNavProps) => {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const titleId = `${menuId}-title`;
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const previousFocusedElement = document.activeElement as HTMLElement | null;
+    const panel = panelRef.current;
+
+    if (panel) {
+      const focusable = getFocusableElements(panel);
+      if (focusable.length > 0) {
+        focusable[0].focus();
+      } else {
+        panel.focus({ preventScroll: true });
+      }
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (event.key !== "Tab") {
+        return;
+      }
+
+      const focusableElements = getFocusableElements(panelRef.current);
+
+      if (focusableElements.length === 0) {
+        event.preventDefault();
+        return;
+      }
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+      const isShiftPressed = event.shiftKey;
+      const activeElement = document.activeElement as HTMLElement | null;
+
+      if (isShiftPressed) {
+        if (activeElement === firstElement) {
+          event.preventDefault();
+          lastElement.focus();
+        }
+        return;
+      }
+
+      if (activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      previousFocusedElement?.focus();
+    };
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = originalOverflow;
+    };
+  }, [isOpen]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-40 flex lg:hidden">
+      <div
+        className="fixed inset-0 bg-slate-950/80"
+        aria-hidden="true"
+        onClick={onClose}
+        role="presentation"
+      />
+      <div
+        ref={panelRef}
+        id={menuId}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="relative ml-auto flex h-full w-80 max-w-[calc(100%-3rem)] flex-col border-l border-slate-800 bg-slate-950 shadow-xl focus:outline-none"
+        tabIndex={-1}
+      >
+        <div className="flex items-center justify-between px-6 py-4">
+          <div>
+            <p id={titleId} className="text-sm font-semibold text-white">
+              Navigacija
+            </p>
+            <p className="text-xs text-slate-400">Pasirinkite sekciją</p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full border border-slate-800 bg-slate-900/70 p-2 text-slate-300 transition hover:border-slate-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+            aria-label="Uždaryti meniu"
+          >
+            <XMarkIcon className="h-5 w-5" />
+          </button>
+        </div>
+        <div className="flex h-full flex-col overflow-y-auto px-6 pb-6">
+          <SidebarContent onNavigate={onClose} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const getFocusableElements = (container: HTMLElement | null): HTMLElement[] => {
+  if (!container) {
+    return [];
+  }
+
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS));
+};
+

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -3,9 +3,21 @@ import { appRoutes } from "../../routes/routeConfig";
 import { SidebarNavLink } from "./SidebarNavLink";
 import { StatusBadge } from "../ui/StatusBadge";
 
+type SidebarContentProps = {
+  onNavigate?: () => void;
+};
+
 export const Sidebar = () => {
   return (
     <aside className="hidden w-72 border-r border-slate-800 bg-slate-950/90 px-6 py-8 lg:flex lg:flex-col">
+      <SidebarContent />
+    </aside>
+  );
+};
+
+export const SidebarContent = ({ onNavigate }: SidebarContentProps) => {
+  return (
+    <>
       <div className="mb-8 flex items-center gap-3">
         <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-brand-400 to-amber-500 text-lg font-semibold text-slate-900 shadow-lg shadow-amber-500/30">
           BM
@@ -21,9 +33,9 @@ export const Sidebar = () => {
         Naujos realaus laiko analizės bus prieinamos su API integracija.
       </div>
 
-      <nav className="flex-1 space-y-1">
+      <nav className="flex-1 space-y-1" aria-label="Pagrindinė navigacija">
         {appRoutes.map((route) => (
-          <SidebarNavLink key={route.id} item={route} />
+          <SidebarNavLink key={route.id} item={route} onNavigate={onNavigate} />
         ))}
       </nav>
 
@@ -44,6 +56,6 @@ export const Sidebar = () => {
           </li>
         </ul>
       </div>
-    </aside>
+    </>
   );
 };

--- a/apps/web/src/components/layout/SidebarNavLink.tsx
+++ b/apps/web/src/components/layout/SidebarNavLink.tsx
@@ -4,13 +4,15 @@ import clsx from "clsx";
 
 type SidebarNavLinkProps = {
   item: AppRoute;
+  onNavigate?: () => void;
 };
 
-export const SidebarNavLink = ({ item }: SidebarNavLinkProps) => {
+export const SidebarNavLink = ({ item, onNavigate }: SidebarNavLinkProps) => {
   return (
     <NavLink
       to={item.path ?? "/"}
       end={item.path === "/"}
+      onClick={onNavigate}
       className={({ isActive }) =>
         clsx(
           "group flex items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium transition",

--- a/apps/web/src/components/layout/TopBar.tsx
+++ b/apps/web/src/components/layout/TopBar.tsx
@@ -1,7 +1,13 @@
-import { MagnifyingGlassIcon, BellAlertIcon, ArrowRightOnRectangleIcon } from "@heroicons/react/24/outline";
+import { MagnifyingGlassIcon, BellAlertIcon, ArrowRightOnRectangleIcon, Bars3Icon } from "@heroicons/react/24/outline";
 import { useAuth } from "../../hooks/useAuth";
 
-export const TopBar = () => {
+type TopBarProps = {
+  isMobileNavOpen: boolean;
+  onToggleMobileNav: () => void;
+  mobileNavId: string;
+};
+
+export const TopBar = ({ isMobileNavOpen, onToggleMobileNav, mobileNavId }: TopBarProps) => {
   const { user, logout, isProcessing } = useAuth();
   const displayName = user?.name ?? "BusMedaus narys";
   const displayRole = user?.role ?? user?.email ?? "Komandos narys";
@@ -10,6 +16,17 @@ export const TopBar = () => {
     <header className="sticky top-0 z-10 border-b border-slate-800 bg-slate-950/70 backdrop-blur">
       <div className="flex items-center justify-between px-6 py-4 lg:px-10">
         <div className="flex items-center gap-4">
+          <button
+            type="button"
+            onClick={onToggleMobileNav}
+            aria-controls={mobileNavId}
+            aria-expanded={isMobileNavOpen}
+            aria-haspopup="dialog"
+            aria-label="Perjungti navigaciją"
+            className="inline-flex h-11 w-11 items-center justify-center rounded-xl border border-slate-800 bg-slate-900/70 text-slate-200 transition hover:border-brand-500/60 hover:text-brand-200 focus:outline-none focus:ring-2 focus:ring-brand-500 lg:hidden"
+          >
+            <Bars3Icon className="h-6 w-6" />
+          </button>
           <div className="hidden flex-col lg:flex">
             <span className="text-xs uppercase tracking-wide text-slate-400">Sveiki sugrįžę</span>
             <span className="text-lg font-semibold text-white">BusMedaus valdymo centras</span>


### PR DESCRIPTION
## Summary
- add a MobileNav drawer with focus trapping and overlay controls for small screens
- refactor AppLayout, TopBar, and Sidebar to reuse navigation content and toggle the drawer
- cover the mobile navigation toggle with a new AppLayout.test.tsx test

## Testing
- npm --prefix apps/web run test *(fails: Vitest requests the optional `jsdom` dependency which cannot be installed in this environment)*
- npm --prefix apps/web run lint *(fails: ESLint configuration depends on `typescript-eslint`, which is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d29dbf05d48333a2223669485af23e