### PR TITLE
Use jsonb metadata columns for notifications and media

### DIFF
--- a/src/media/media-item.entity.ts
+++ b/src/media/media-item.entity.ts
@@ -24,7 +24,7 @@ export class MediaItem {
   @Column({ nullable: true })
   description?: string;
 
-  @Column({ type: 'simple-json', nullable: true })
+  @Column({ type: 'jsonb', nullable: true })
   metadata?: Record<string, unknown> | null;
 
   @ManyToOne(() => Hive, (hive) => hive.mediaItems, { onDelete: 'CASCADE', eager: true })

--- a/src/media/media.service.ts
+++ b/src/media/media.service.ts
@@ -62,7 +62,7 @@ export class MediaService {
           url: dto.url,
           mimeType: dto.mimeType,
           description: dto.description,
-          metadata: dto.metadata ?? null,
+          metadata: dto.metadata,
           inspectionId: dto.inspectionId,
           taskId: dto.taskId,
           harvestId: dto.harvestId,

--- a/src/notifications/notification-subscription.entity.ts
+++ b/src/notifications/notification-subscription.entity.ts
@@ -26,7 +26,7 @@ export class NotificationSubscription {
   @Column({ length: 50, default: 'web' })
   platform!: string;
 
-  @Column({ type: 'simple-json', nullable: true })
+  @Column({ type: 'jsonb', nullable: true })
   metadata?: Record<string, unknown> | null;
 
   @Column({ type: 'timestamptz', nullable: true })

--- a/src/notifications/notification.entity.ts
+++ b/src/notifications/notification.entity.ts
@@ -67,10 +67,10 @@ export class Notification {
   @Column({ nullable: true })
   auditEventId?: string;
 
-  @Column({ type: 'simple-json', nullable: true })
+  @Column({ type: 'jsonb', nullable: true })
   metadata?: Record<string, unknown> | null;
 
-  @Column({ type: 'simple-json', nullable: true })
+  @Column({ type: 'jsonb', nullable: true })
   deliveryMetadata?: NotificationDeliveryMap | null;
 
   @Column({ type: 'timestamptz', nullable: true })

--- a/src/notifications/notifications.service.ts
+++ b/src/notifications/notifications.service.ts
@@ -130,7 +130,9 @@ export class NotificationsService {
       if (subscription) {
         subscription.user = user;
         subscription.platform = payload.platform ?? subscription.platform;
-        subscription.metadata = payload.metadata ?? subscription.metadata ?? null;
+        if (payload.metadata !== undefined) {
+          subscription.metadata = payload.metadata;
+        }
         subscription.lastUsedAt = now;
       } else {
         subscription = this.notificationSubscriptionsRepository.create(
@@ -138,7 +140,7 @@ export class NotificationsService {
             user,
             token: payload.token,
             platform: payload.platform ?? 'web',
-            metadata: payload.metadata ?? null,
+            metadata: payload.metadata,
             lastUsedAt: now
           },
           manager


### PR DESCRIPTION
## Summary
- switch notification, notification subscription, and media metadata columns to jsonb so TypeORM no longer serializes them as simple-json
- keep metadata handling in services working with plain objects by removing unused null coercion

## Testing
- npm run build *(fails: apps/web/tsconfig.app.json excludes src/tasks/task-status.enum.ts)*
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2a91d58588333944d3a1e33ca3aad