### PR TITLE
Document web console API usage and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ volume between runs.
 ## Web console
 
 A modern React + Vite front-end lives under `apps/web`. It mirrors the existing UI screenshots in `static/photos` and is
-powered by Tailwind CSS, ESLint/Prettier, and Vitest with React Testing Library. Until the backend API is available, the
-screens rely on deterministic mock services so developers can iterate on layout and interactions.
+powered by Tailwind CSS, ESLint/Prettier, and Vitest with React Testing Library. The console now uses React Query and the
+shared `apiClient` to call the live NestJS API routes (for example, `/tasks`, `/hives`, `/users`, and `/notifications`) so
+you see real data while iterating on the UI.
 
 Useful commands:
 
@@ -74,6 +75,13 @@ npm run test:web
 
 `npm run build` now compiles the React console before producing the backend bundle, writing optimised assets to
 `dist/web`. The NestJS server can later serve these files once the integration layer is prepared.
+
+### Front-end environment configuration
+
+The Vite dev server expects an API URL at build time. Set the `VITE_API_BASE_URL` environment variable (for example,
+`http://localhost:3000`) before running `npm run dev:web` so the console proxies requests to your backend. You can place the
+value in `apps/web/.env.local`, export it in your shell session, or inject it through your process manager. When the setting
+is in place, the UI surfaces the same task, hive, and messaging data served by the NestJS instance.
 
 ## Key features
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -2,8 +2,8 @@
 
 This package contains the Vite + React (TypeScript) front-end that mirrors the legacy screenshots in `../../static/photos`.
 It uses Tailwind CSS for styling primitives, ESLint + Prettier for formatting, and Vitest with React Testing Library for UI
-contracts. Until the production API is live the screens fetch data from deterministic mock services so that the component
-structure matches the expected backend payloads.
+contracts. The app mounts React Query hooks backed by the shared `apiClient`, so every console view calls the live NestJS API
+routes (such as `/tasks`, `/hives`, and `/users`) instead of deterministic mocks.
 
 ## Available scripts
 
@@ -18,3 +18,16 @@ npm run preview       # serve the production build locally
 
 The production build writes hashed assets to `../../dist/web`. When the NestJS backend is ready to serve static files it can
 point to that directory and expose `index.html` as the entry point.
+
+## Configuring the API target
+
+Vite reads the backend base URL from the `VITE_API_BASE_URL` environment variable. Set it to the running NestJS instance (for
+example, `http://localhost:3000`) before starting the dev server or building the bundle:
+
+```bash
+VITE_API_BASE_URL=http://localhost:3000 npm run dev
+```
+
+You can also create an `.env.local` file alongside this README with the same variable so `npm run dev` and `npm run build` use
+the correct API automatically. When configured, the console renders the real task, hive, and notification data managed by the
+backend.


### PR DESCRIPTION
## Summary
- update the root README to describe how the Vite console talks to the live NestJS API via React Query and apiClient
- explain how to set VITE_API_BASE_URL so the console can reach the backend during local development
- mirror the API usage and environment configuration guidance in apps/web/README.md

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d39367a57483338353acbef5c7f42e