### PR TITLE
Expose logout control on mobile

### DIFF
--- a/apps/web/src/components/layout/AppLayout.test.tsx
+++ b/apps/web/src/components/layout/AppLayout.test.tsx
@@ -34,7 +34,10 @@ const renderWithProviders = (ui: ReactElement) => {
     </MemoryRouter>
   );
 
-  return render(ui, { wrapper: Wrapper });
+  return {
+    authValue,
+    ...render(ui, { wrapper: Wrapper })
+  };
 };
 
 describe("AppLayout", () => {
@@ -63,5 +66,23 @@ describe("AppLayout", () => {
 
     expect(screen.queryByRole("dialog", { name: /navigacija/i })).not.toBeInTheDocument();
     expect(toggle).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("provides a visible and clickable logout control on mobile", async () => {
+    const { authValue } = renderWithProviders(
+      <AppLayout>
+        <p>Turinys</p>
+      </AppLayout>
+    );
+
+    const logoutButton = screen.getByRole("button", { name: /atsijungti/i });
+    expect(logoutButton).toBeInTheDocument();
+    expect(logoutButton).not.toHaveClass("hidden");
+    expect(logoutButton).toBeEnabled();
+
+    const user = userEvent.setup();
+    await user.click(logoutButton);
+
+    expect(authValue.logout).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/components/layout/TopBar.tsx
+++ b/apps/web/src/components/layout/TopBar.tsx
@@ -63,7 +63,7 @@ export const TopBar = ({ isMobileNavOpen, onToggleMobileNav, mobileNavId }: TopB
             type="button"
             onClick={() => void logout()}
             disabled={isProcessing}
-            className="hidden rounded-full border border-slate-800 bg-slate-900/70 p-2 text-slate-300 transition hover:border-rose-500/60 hover:text-rose-200 disabled:cursor-not-allowed disabled:opacity-50 sm:inline-flex"
+            className="inline-flex rounded-full border border-slate-800 bg-slate-900/70 p-2 text-slate-300 transition hover:border-rose-500/60 hover:text-rose-200 disabled:cursor-not-allowed disabled:opacity-50"
             aria-label="Atsijungti"
           >
             <ArrowRightOnRectangleIcon className="h-5 w-5" />


### PR DESCRIPTION
## Summary
- show the logout button in the top bar for all breakpoints so it stays accessible on small screens
- extend the app layout test helper to return auth mocks and assert the mobile logout control is present, enabled, and triggers logout

## Testing
- npm --prefix apps/web run test *(fails: missing optional dependency "jsdom" and installation is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3adeb30ec8333b84fd23b260b6655