### PR TITLE
Add localized labels for manager and member roles

### DIFF
--- a/apps/web/src/features/users/UsersPage.test.tsx
+++ b/apps/web/src/features/users/UsersPage.test.tsx
@@ -39,7 +39,7 @@ describe("UsersPage", () => {
         firstName: "Ada",
         lastName: "Lovelace",
         phoneNumber: "+37060000001",
-        roles: ["admin"],
+        roles: ["member"],
         isActive: true,
         createdAt: new Date("2024-01-05T08:45:00.000Z").toISOString(),
         updatedAt: new Date("2024-01-10T08:45:00.000Z").toISOString()
@@ -52,7 +52,7 @@ describe("UsersPage", () => {
 
     await waitFor(() => expect(screen.getByText("Ada Lovelace")).toBeInTheDocument());
 
-    expect(screen.getByText("Administratorius")).toBeInTheDocument();
+    expect(screen.getByText("Komandos narys")).toBeInTheDocument();
     expect(screen.getByText("ada@example.com • +37060000001")).toBeInTheDocument();
     expect(screen.getByText(/Komandoje nuo/)).toBeInTheDocument();
     expect(spy).toHaveBeenCalledWith("/users");

--- a/apps/web/src/features/users/userMapper.test.ts
+++ b/apps/web/src/features/users/userMapper.test.ts
@@ -50,6 +50,35 @@ describe("mapSafeUserToTeamMember", () => {
     expect(member.activeSince).toBe("nežinoma");
   });
 
+  it("localizes recognized roles", () => {
+    const manager = mapSafeUserToTeamMember({
+      ...baseUser,
+      id: "user-3",
+      roles: ["manager"]
+    });
+
+    const member = mapSafeUserToTeamMember({
+      ...baseUser,
+      id: "user-4",
+      roles: ["member"]
+    });
+
+    expect(manager.role).toBe("Vadovas");
+    expect(member.role).toBe("Komandos narys");
+  });
+
+  it("falls back to title case for unknown roles", () => {
+    const payload: SafeUser = {
+      ...baseUser,
+      id: "user-5",
+      roles: ["lead_engineer"]
+    };
+
+    const member = mapSafeUserToTeamMember(payload);
+
+    expect(member.role).toBe("Lead Engineer");
+  });
+
   it("produces deterministic avatar colors based on the user identifier", () => {
     const first = mapSafeUserToTeamMember(baseUser);
     const second = mapSafeUserToTeamMember({ ...baseUser });

--- a/apps/web/src/features/users/userMapper.ts
+++ b/apps/web/src/features/users/userMapper.ts
@@ -6,7 +6,9 @@ const ROLE_LABELS: Record<string, string> = {
   analyst: "Analitikas",
   inspector: "Inspektorius",
   viewer: "Stebėtojas",
-  auditor: "Auditorius"
+  auditor: "Auditorius",
+  manager: "Vadovas",
+  member: "Komandos narys"
 };
 
 const AVATAR_COLORS = [


### PR DESCRIPTION
## Summary
- add localized translations for manager and member role identifiers
- cover the new role labels and title-case fallback in the user mapper tests
- update the UsersPage test expectation for the Komandos narys label

## Testing
- CI=1 npm --prefix apps/web run test *(fails: missing dependency 'jsdom' in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3adf36ce88333bf36d0214f9294f5