### PR TITLE
Clarify data source messaging on web feature pages

### DIFF
--- a/apps/web/src/features/messaging/MessagingPage.tsx
+++ b/apps/web/src/features/messaging/MessagingPage.tsx
@@ -126,7 +126,7 @@ const MessagingPage = () => {
     <div className="grid gap-6 lg:grid-cols-3">
       <Card
         title="Komunikacijos centras"
-        subtitle="Kai backend'as bus paruoštas, čia bus rodomi realūs pokalbiai ir failų mainai"
+        subtitle="Duomenys kraunami iš API ir pateikiami realių pokalbių santraukoje"
         className="lg:col-span-1"
       >
         <div className="space-y-3">

--- a/apps/web/src/features/notifications/NotificationsPage.tsx
+++ b/apps/web/src/features/notifications/NotificationsPage.tsx
@@ -356,7 +356,7 @@ const NotificationsPage = () => {
 
       <Card
         title="Naujausi įrašai"
-        subtitle="Kai bus prijungtas backend'as, čia atsinaujins visų modulių įvykiai"
+        subtitle="Duomenys kraunami iš API ir nuolat papildomi naujausiais įvykiais"
         accent={<BellAlertIcon className="h-6 w-6 text-amber-300" />}
       >
         <ul className="space-y-4">

--- a/apps/web/src/features/tasks/TasksPage.tsx
+++ b/apps/web/src/features/tasks/TasksPage.tsx
@@ -148,7 +148,7 @@ const TasksPage = () => {
 
       <Card
         title="Užduočių sąrašas"
-        subtitle="Kai API bus aktyvus, čia matysite realaus laiko progresą ir komentarus"
+        subtitle="Duomenys kraunami iš API ir atnaujinami po kiekvieno pakeitimo"
       >
         <div className="overflow-hidden rounded-xl border border-slate-800">
           <table className="min-w-full divide-y divide-slate-800 text-sm">


### PR DESCRIPTION
## Summary
- update the tasks dashboard subtitle to reflect its live API-backed data
- refresh notifications page copy to note API-driven activity updates
- align messaging center subtitle with current API conversation feed

## Testing
- `npm --prefix apps/web run test` *(fails: Vitest prompts for missing jsdom dependency and cannot install it in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c365e2908333a0e45bfb353e7660