### PR TITLE
Handle localStorage failures in auth

### DIFF
--- a/apps/web/src/providers/AuthProvider.test.tsx
+++ b/apps/web/src/providers/AuthProvider.test.tsx
@@ -73,4 +73,64 @@ describe("AuthProvider", () => {
       queryClient.clear();
     }
   });
+
+  it("keeps authentication active when persisting to localStorage fails", async () => {
+    const queryClient = new QueryClient();
+    const wrapper = createWrapper(queryClient);
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    const tokenResponse: TokenResponse = {
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      user: { id: "1", email: "user@example.com", name: "Test User" }
+    };
+
+    const postMock = vi
+      .spyOn(apiClient, "post")
+      .mockImplementation(async (path: string, _body?: unknown, _options?: unknown) => {
+        if (path === "/auth/login") {
+          return tokenResponse;
+        }
+        throw new Error(`Unexpected path: ${path}`);
+      });
+
+    const setItemMock = vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
+      throw new Error("Quota exceeded");
+    });
+
+    const consoleWarnMock = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      await act(async () => {
+        await result.current.login({ email: "user@example.com", password: "password" });
+      });
+
+      expect(result.current.status).toBe("authenticated");
+      expect(result.current.user).not.toBeNull();
+      expect(result.current.isAuthenticated).toBe(true);
+
+      if (import.meta.env?.DEV) {
+        expect(consoleWarnMock).toHaveBeenCalled();
+      }
+
+      expect(setItemMock).toHaveBeenCalledTimes(1);
+      const [, persistedPayload] = setItemMock.mock.calls[0];
+      expect(typeof persistedPayload).toBe("string");
+
+      if (typeof persistedPayload === "string") {
+        const parsedPayload = JSON.parse(persistedPayload);
+
+        expect(parsedPayload).toMatchObject({
+          user: tokenResponse.user,
+          session: {
+            accessToken: tokenResponse.accessToken,
+            refreshToken: tokenResponse.refreshToken
+          }
+        });
+        expect(typeof parsedPayload.session.expiresAt).toBe("number");
+      }
+    } finally {
+      queryClient.clear();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- guard auth localStorage helpers so quota errors log warnings instead of breaking the flow
- keep login state active when persistence fails by catching storage errors
- add a regression test that stubs localStorage.setItem throwing and verifies login stays authenticated

## Testing
- CI=1 npm --prefix apps/web run test *(fails: missing jsdom dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3d35e94388333a5d6723aca773754