### PR TITLE
refactor: remove guard registrations from auth module

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -5,13 +5,11 @@ import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { RefreshToken } from './refresh-token.entity';
 import { RefreshTokenRepository } from './refresh-token.repository';
-import { JwtAuthGuard } from './guards/jwt-auth.guard';
-import { RolesGuard } from './guards/roles.guard';
 
 @Module({
   imports: [TypeOrmModule.forFeature([RefreshToken]), UsersModule],
   controllers: [AuthController],
-  providers: [AuthService, RefreshTokenRepository, JwtAuthGuard, RolesGuard],
-  exports: [AuthService, JwtAuthGuard, RolesGuard]
+  providers: [AuthService, RefreshTokenRepository],
+  exports: [AuthService]
 })
 export class AuthModule {}


### PR DESCRIPTION
## Summary
- remove JwtAuthGuard and RolesGuard from the AuthModule provider and export lists while keeping AuthService and RefreshTokenRepository registered

## Testing
- npm run build *(fails: TS6307 - apps/web/src/features/tasks/taskOptions.ts references ../../../../src/tasks/task-status.enum.ts which is not included in tsconfig.app.json)*

------
https://chatgpt.com/codex/tasks/task_e_68de46e1ab188333a370c0acaa7475c3