### PR TITLE
Ensure audit log user reference uses uuid type

### DIFF
--- a/src/audit/audit-log.entity.ts
+++ b/src/audit/audit-log.entity.ts
@@ -5,7 +5,7 @@ export class AuditLog {
   @PrimaryGeneratedColumn('uuid')
   id!: string;
 
-  @Column({ nullable: true })
+  @Column({ type: 'uuid', nullable: true })
   userId?: string | null;
 
   @Column()


### PR DESCRIPTION
## Summary
- enforce the audit log userId column to use the uuid type so the entity matches the database schema

## Testing
- npm run db:migrate *(fails: no PostgreSQL instance available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de478539808333a78591f14a7f84e2