### PR TITLE
Add local Vite API base URL configuration

### DIFF
--- a/apps/web/.env.local
+++ b/apps/web/.env.local
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:3000


### PR DESCRIPTION
## Summary
- add an .env.local file for the web app so Vite exposes the API base URL locally

## Testing
- timeout 5s npm run dev:web

------
https://chatgpt.com/codex/tasks/task_e_68de4f5cd9b883339a9ba7b565daccfb