### PR TITLE
Fix circular dependency between auth and users modules

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersModule } from '../users/users.module';
 import { AuthController } from './auth.controller';
@@ -7,7 +7,7 @@ import { RefreshToken } from './refresh-token.entity';
 import { RefreshTokenRepository } from './refresh-token.repository';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([RefreshToken]), UsersModule],
+  imports: [TypeOrmModule.forFeature([RefreshToken]), forwardRef(() => UsersModule)],
   controllers: [AuthController],
   providers: [AuthService, RefreshTokenRepository],
   exports: [AuthService]

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Inject, Injectable, UnauthorizedException, forwardRef } from '@nestjs/common';
 import { DataSource, EntityManager } from 'typeorm';
 import * as bcrypt from 'bcryptjs';
 import * as jwt from 'jsonwebtoken';
@@ -52,6 +52,7 @@ export class AuthService {
   private readonly refreshTokenTtlMs = Number(process.env.JWT_REFRESH_TTL_MS || 1000 * 60 * 60 * 24 * 7);
 
   constructor(
+    @Inject(forwardRef(() => UsersService))
     private readonly usersService: UsersService,
     private readonly refreshTokenRepository: RefreshTokenRepository,
     private readonly dataSource: DataSource

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from '../auth/auth.module';
 import { UsersController } from './users.controller';
@@ -7,7 +7,7 @@ import { UsersRepository } from './users.repository';
 import { UsersService } from './users.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User]), AuthModule],
+  imports: [TypeOrmModule.forFeature([User]), forwardRef(() => AuthModule)],
   controllers: [UsersController],
   providers: [UsersService, UsersRepository],
   exports: [UsersService, UsersRepository]


### PR DESCRIPTION
## Summary
- wrap the auth and users modules in forward references to resolve circular dependency
- update AuthService to inject UsersService using a forwardRef-aware decorator

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de67c27d3083338051dad9505d8c0c