### PR TITLE
Add npm database reset workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ against the database configured by `DB_HOST`, `DB_PORT`, `DB_USERNAME`, `DB_PASS
 Populate development fixtures by running `npm run db:seed` after the migrations complete. The seed script uses the same connection
 settings to insert baseline users, hives, and tasks that help during local testing.
 
+Use `npm run db:reset` to drop the existing schema and rebuild it from scratch. The script clears all tables with TypeORM's
+`clearDatabase` helper before chaining the migration and seed routines so you can recover a clean environment quickly.
+
 ### Docker Compose workflow
 
 The Compose profile described in [Option A](#option-a-docker-compose) provisions PostgreSQL 16 and the API service in one stack. It installs dependencies, builds the project, runs migrations and seeds, and then launches the NestJS server connected to the `postgres` service. PostgreSQL data persists in the `postgres-data` named volume between runs.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev:web": "npm --prefix apps/web run dev",
     "lint": "eslint .",
     "lint:web": "npm --prefix apps/web run lint",
+    "db:reset": "ts-node src/database/reset.ts && npm run db:migrate && npm run db:seed",
     "db:migrate": "ts-node src/database/run-migrations.ts",
     "db:seed": "ts-node src/database/seed.ts",
     "test": "jest --runInBand",

--- a/src/database/reset.ts
+++ b/src/database/reset.ts
@@ -1,0 +1,24 @@
+import 'reflect-metadata';
+import { AppDataSource } from './data-source';
+
+async function dropSchema() {
+  console.log('Initializing database connection...');
+  await AppDataSource.initialize();
+  try {
+    console.log('Dropping existing schema...');
+    const queryRunner = AppDataSource.createQueryRunner();
+    try {
+      await queryRunner.clearDatabase();
+    } finally {
+      await queryRunner.release();
+    }
+    console.log('Schema dropped. Ready to rerun migrations.');
+  } finally {
+    await AppDataSource.destroy();
+  }
+}
+
+dropSchema().catch((error) => {
+  console.error('Failed to reset database schema', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add an npm `db:reset` script that chains schema drop, migrations, and seeds
- create a TypeORM reset routine that clears the existing schema via `AppDataSource`
- document the reset workflow so developers can rebuild a clean database locally

## Testing
- npm run db:reset *(fails: connection refused to localhost:5432 because PostgreSQL is not running in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de70daa8a883339a603d626a971ab8