### PR TITLE
Ensure shared JwtAuthGuard availability across modules

### DIFF
--- a/src/audit/audit.module.ts
+++ b/src/audit/audit.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from '../auth/auth.module';
 import { AuditController } from './audit.controller';
 import { AuditLog } from './audit-log.entity';
 import { AuditMiddleware } from './audit.middleware';
@@ -7,7 +8,7 @@ import { AuditRepository } from './audit.repository';
 import { AuditService } from './audit.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([AuditLog])],
+  imports: [TypeOrmModule.forFeature([AuditLog]), AuthModule],
   controllers: [AuditController],
   providers: [AuditService, AuditRepository, AuditMiddleware],
   exports: [AuditService, AuditRepository, AuditMiddleware]

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -3,13 +3,14 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersModule } from '../users/users.module';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { RefreshToken } from './refresh-token.entity';
 import { RefreshTokenRepository } from './refresh-token.repository';
 
 @Module({
   imports: [TypeOrmModule.forFeature([RefreshToken]), forwardRef(() => UsersModule)],
   controllers: [AuthController],
-  providers: [AuthService, RefreshTokenRepository],
-  exports: [AuthService]
+  providers: [AuthService, RefreshTokenRepository, JwtAuthGuard],
+  exports: [AuthService, JwtAuthGuard]
 })
 export class AuthModule {}

--- a/src/dashboard/dashboard.module.ts
+++ b/src/dashboard/dashboard.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
 import { HivesModule } from '../hives/hives.module';
 import { MediaModule } from '../media/media.module';
 import { MessagingModule } from '../messaging/messaging.module';
@@ -8,7 +9,7 @@ import { DashboardController } from './dashboard.controller';
 import { DashboardService } from './dashboard.service';
 
 @Module({
-  imports: [HivesModule, TasksModule, NotificationsModule, MediaModule, MessagingModule],
+  imports: [HivesModule, TasksModule, NotificationsModule, MediaModule, MessagingModule, AuthModule],
   controllers: [DashboardController],
   providers: [DashboardService]
 })

--- a/src/hives/hives.module.ts
+++ b/src/hives/hives.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from '../auth/auth.module';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { UsersModule } from '../users/users.module';
 import { Hive } from './hive.entity';
@@ -8,7 +9,7 @@ import { HivesRepository } from './hives.repository';
 import { HivesService } from './hives.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Hive]), UsersModule, NotificationsModule],
+  imports: [TypeOrmModule.forFeature([Hive]), UsersModule, NotificationsModule, AuthModule],
   controllers: [HivesController],
   providers: [HivesService, HivesRepository],
   exports: [HivesService, HivesRepository]

--- a/src/media/media.module.ts
+++ b/src/media/media.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from '../auth/auth.module';
 import { HivesModule } from '../hives/hives.module';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { UsersModule } from '../users/users.module';
@@ -9,7 +10,7 @@ import { MediaRepository } from './media.repository';
 import { MediaService } from './media.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([MediaItem]), HivesModule, UsersModule, NotificationsModule],
+  imports: [TypeOrmModule.forFeature([MediaItem]), HivesModule, UsersModule, NotificationsModule, AuthModule],
   controllers: [MediaController],
   providers: [MediaService, MediaRepository],
   exports: [MediaService, MediaRepository]

--- a/src/messaging/messaging.module.ts
+++ b/src/messaging/messaging.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from '../auth/auth.module';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { TasksModule } from '../tasks/tasks.module';
 import { UsersModule } from '../users/users.module';
@@ -9,7 +10,7 @@ import { MessagingController } from './messaging.controller';
 import { MessagingService } from './messaging.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Comment]), TasksModule, UsersModule, NotificationsModule],
+  imports: [TypeOrmModule.forFeature([Comment]), TasksModule, UsersModule, NotificationsModule, AuthModule],
   controllers: [MessagingController],
   providers: [MessagingService, CommentsRepository],
   exports: [MessagingService, CommentsRepository]

--- a/src/notifications/notifications.module.ts
+++ b/src/notifications/notifications.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import sgMail, { MailService } from '@sendgrid/mail';
 import { cert, getApps, initializeApp } from 'firebase-admin/app';
 import { getMessaging, Messaging } from 'firebase-admin/messaging';
+import { AuthModule } from '../auth/auth.module';
 import { UsersModule } from '../users/users.module';
 import { Notification } from './notification.entity';
 import { NotificationsController } from './notifications.controller';
@@ -70,7 +71,7 @@ const firebaseMessagingProvider = {
 };
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Notification, NotificationSubscription]), UsersModule],
+  imports: [TypeOrmModule.forFeature([Notification, NotificationSubscription]), UsersModule, AuthModule],
   controllers: [NotificationsController],
   providers: [
     NotificationsService,

--- a/src/tasks/tasks.module.ts
+++ b/src/tasks/tasks.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from '../auth/auth.module';
 import { HivesModule } from '../hives/hives.module';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { UsersModule } from '../users/users.module';
@@ -9,7 +10,7 @@ import { TasksRepository } from './tasks.repository';
 import { TasksService } from './tasks.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Task]), HivesModule, UsersModule, NotificationsModule],
+  imports: [TypeOrmModule.forFeature([Task]), HivesModule, UsersModule, NotificationsModule, AuthModule],
   controllers: [TasksController],
   providers: [TasksService, TasksRepository],
   exports: [TasksService, TasksRepository]


### PR DESCRIPTION
## Summary
- provide the JwtAuthGuard from AuthModule so it can be reused by other modules
- import AuthModule wherever controllers rely on JwtAuthGuard to share the same guard instance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df9496797c8333b3903272a65e9514