### PR TITLE
Add health check endpoint and module

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,6 +11,7 @@ import { TasksModule } from './tasks/tasks.module';
 import { HivesModule } from './hives/hives.module';
 import { UsersModule } from './users/users.module';
 import { InitialSchema1700000000300 } from './migrations/1700000000300-initial-schema';
+import { HealthModule } from './health/health.module';
 
 @Module({
   imports: [
@@ -39,7 +40,8 @@ import { InitialSchema1700000000300 } from './migrations/1700000000300-initial-s
     NotificationsModule,
     MessagingModule,
     MediaModule,
-    DashboardModule
+    DashboardModule,
+    HealthModule
   ]
 })
 export class AppModule implements NestModule {

--- a/src/health/__tests__/health.e2e-spec.ts
+++ b/src/health/__tests__/health.e2e-spec.ts
@@ -1,0 +1,28 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { HealthModule } from '../health.module';
+
+describe('HealthController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [HealthModule]
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should return ok status', async () => {
+    await request(app.getHttpServer())
+      .get('/health')
+      .expect(200)
+      .expect({ status: 'ok' });
+  });
+});

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('health')
+export class HealthController {
+  @Get()
+  check() {
+    return { status: 'ok' };
+  }
+}

--- a/src/health/health.module.ts
+++ b/src/health/health.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { HealthController } from './health.controller';
+
+@Module({
+  controllers: [HealthController]
+})
+export class HealthModule {}


### PR DESCRIPTION
## Summary
- add a health controller and module exposing GET /health returning a simple status payload
- register the HealthModule within the application module
- add an end-to-end test to verify the /health endpoint response

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df95eadc3c833390c7218f54a415ad