### PR TITLE
Align TypeORM migration configuration

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,27 +10,14 @@ import { NotificationsModule } from './notifications/notifications.module';
 import { TasksModule } from './tasks/tasks.module';
 import { HivesModule } from './hives/hives.module';
 import { UsersModule } from './users/users.module';
-import { InitialSchema1700000000300 } from './migrations/1700000000300-initial-schema';
 import { HealthModule } from './health/health.module';
+import { AppDataSource } from './database/data-source';
 
 @Module({
   imports: [
     TypeOrmModule.forRoot({
-      type: 'postgres',
-      host: process.env.DB_HOST || 'localhost',
-      port: parseInt(process.env.DB_PORT ?? '5432', 10),
-      username: process.env.DB_USERNAME || process.env.DB_USER || 'postgres',
-      password: process.env.DB_PASSWORD || 'postgres',
-      database: process.env.DB_NAME || 'busmedaus',
-      autoLoadEntities: true,
-      synchronize: false,
-      migrationsRun: true,
-      migrations: [InitialSchema1700000000300],
-      migrationsTableName: 'typeorm_migrations',
-      ssl:
-        process.env.DB_SSL === 'true'
-          ? { rejectUnauthorized: process.env.DB_SSL_REJECT_UNAUTHORIZED !== 'false' }
-          : false
+      ...AppDataSource.options,
+      autoLoadEntities: true
     }),
     AuditModule,
     AuthModule,

--- a/src/database/data-source.ts
+++ b/src/database/data-source.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import { DataSource } from 'typeorm';
 import { User } from '../users/user.entity';
 import { Hive } from '../hives/hive.entity';
@@ -7,7 +8,6 @@ import { NotificationSubscription } from '../notifications/notification-subscrip
 import { MediaItem } from '../media/media-item.entity';
 import { Comment } from '../messaging/comment.entity';
 import { RefreshToken } from '../auth/refresh-token.entity';
-import { InitialSchema1700000000300 } from '../migrations/1700000000300-initial-schema';
 
 const getBoolean = (value: string | undefined, fallback = false): boolean => {
   if (value === undefined) {
@@ -25,7 +25,8 @@ export const AppDataSource = new DataSource({
   database: process.env.DB_NAME || 'busmedaus',
   ssl: getBoolean(process.env.DB_SSL) ? { rejectUnauthorized: process.env.DB_SSL_REJECT_UNAUTHORIZED !== 'false' } : false,
   entities: [User, Hive, Task, Notification, NotificationSubscription, MediaItem, Comment, RefreshToken],
-  migrations: [InitialSchema1700000000300],
+  migrations: [path.join(__dirname, '../migrations/*.js')],
   migrationsTableName: 'typeorm_migrations',
+  migrationsRun: true,
   synchronize: false
 });


### PR DESCRIPTION
## Summary
- point the runtime data source at compiled migration files and enable automatic migration execution
- reuse the shared data source configuration in the NestJS TypeORM module to keep settings consistent

## Testing
- npm run build
- npx typeorm-ts-node-commonjs migration:show -d dist/database/data-source.js *(fails: database not available in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df990b14bc8333965f36c889f856d0