### PR TITLE
Use configurable port and host for Nest server

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,8 @@ async function bootstrap() {
     origin: process.env.WEB_ORIGIN?.split(',') ?? ['http://localhost:5173'],
     credentials: true
   });
-  await app.listen(3000);
+  const port = Number(process.env.PORT ?? 3000);
+  await app.listen(port, '0.0.0.0');
 }
 
 bootstrap();


### PR DESCRIPTION
## Summary
- derive the listening port from the PORT environment variable with a fallback to 3000
- bind the NestJS application server to 0.0.0.0 to ensure it is reachable in containerized environments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfa46187ac833380186d2d8c8b690c