### PR TITLE
Adjust web build output directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY package*.json ./
 RUN npm install --omit=dev
 
 COPY --from=builder /app/dist ./dist
-COPY --from=builder /app/dist/web ./dist/web
+COPY --from=builder /app/apps/web/dist ./dist/web
 COPY --from=builder /app/static ./static
 
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ npm run test:web
 ```
 
 `npm run build` now compiles the React console before producing the backend bundle, writing optimised assets to
-`dist/web`. The NestJS server can later serve these files once the integration layer is prepared.
+`apps/web/dist`. The NestJS server can later serve these files once the integration layer is prepared.
 
 ### Front-end environment configuration
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -16,8 +16,8 @@ npm run test          # execute Vitest + React Testing Library
 npm run preview       # serve the production build locally
 ```
 
-The production build writes hashed assets to `../../dist/web`. When the NestJS backend is ready to serve static files it can
-point to that directory and expose `index.html` as the entry point.
+The production build writes hashed assets to the local `dist` directory. When the NestJS backend is ready to serve static
+files it can point to that directory and expose `index.html` as the entry point.
 
 ## Configuring the API target
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     }
   },
   build: {
-    outDir: "../../dist/web",
+    outDir: "dist",
     emptyOutDir: true
   }
 });


### PR DESCRIPTION
## Summary
- update the Vite build output to use the package-local dist directory
- refresh documentation and Docker copy paths to align with the new build target

## Testing
- npm --prefix apps/web run build *(fails: missing vite-related type definitions in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfa4661a388333a786de2c323451ca