### PR TITLE
chore: adjust dockerfile for render pipeline

### DIFF
--- a/Dockerfile.render.off
+++ b/Dockerfile.render.off
@@ -9,7 +9,8 @@ COPY .eslintrc.json ./
 COPY jest.config.ts ./
 COPY apps/web/package*.json ./apps/web/
 
-RUN npm install
+RUN npm ci --ignore-scripts
+RUN npm --prefix apps/web ci --legacy-peer-deps
 
 COPY . .
 
@@ -21,7 +22,7 @@ ENV NODE_ENV=production
 
 COPY package*.json ./
 
-RUN npm install --omit=dev
+RUN npm ci --omit=dev --ignore-scripts
 
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/apps/web/dist ./dist/web


### PR DESCRIPTION
## Summary
- rename the root Dockerfile to Dockerfile.render.off so Render uses the Node build pipeline
- update the Docker build instructions to rely on npm ci flows for the root and apps/web packages and production install

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68dfa903a8388333b7bbb535591a1ae0